### PR TITLE
feat: extend points/wheel-effects API and add system parameters

### DIFF
--- a/src/api-facade/api/apiGames.ts
+++ b/src/api-facade/api/apiGames.ts
@@ -37,6 +37,7 @@ export const apiGames = {
 			.then(({ body }) => convertGameDto(body)),
 
 	postFinishCurrent: () => http.post('/games/current/finish'),
+
 	postCancelCurrent: () => http.post('/games/current/cancel'),
 
 	getHistory: ({ path: { login } }: GetGamesHistory['request']) =>

--- a/src/api-facade/api/apiPoints.ts
+++ b/src/api-facade/api/apiPoints.ts
@@ -1,8 +1,22 @@
 import { http } from '../http'
 import type {
+	GetExperiencePoints,
+	GetFreePoints,
+	GetFreePointsHistory,
 	GetPointsAllInfo,
 	GetPointsInfo,
+	GetTerritoryHours,
+	GetTerritoryPoints,
+	GetTerritoryPointsHistory,
+	PostExperiencePoints,
+	PostFreePoints,
+	PostTerritoryHours,
+	PostTerritoryPoints,
 } from '../requests/points-requests'
+import {
+	convertFreePointChangeHistoryDto,
+	convertTerritoryPointChangeHistoryDto,
+} from '../dto.ts'
 
 export const apiPoints = {
 	getPointsInfo: ({ path: { login } }: GetPointsInfo['request']) =>
@@ -10,4 +24,63 @@ export const apiPoints = {
 
 	getPointsAllInfo: () =>
 		http.get<GetPointsAllInfo>('/points/all/info').then(({ body }) => body),
+
+	postTerritoryPoints: ({
+		body,
+		path: { login },
+	}: PostTerritoryPoints['request']) =>
+		http
+			.post<PostTerritoryPoints>(`/points/${login}/territory-points`, { body })
+			.then(({ body }) => body),
+
+	getTerritoryPoints: ({ path: { login } }: GetTerritoryPoints['request']) =>
+		http
+			.get<GetTerritoryPoints>(`/points/${login}/territory-points`)
+			.then(({ body }) => body),
+
+	getTerritoryPointsHistory: ({
+		path: { login },
+	}: GetTerritoryPointsHistory['request']) =>
+		http
+			.get<GetTerritoryPointsHistory>(
+				`/points/${login}/territory-points/history`,
+			)
+			.then(({ body }) => body.map(convertTerritoryPointChangeHistoryDto)),
+
+	postFreePoints: ({ body, path: { login } }: PostFreePoints['request']) =>
+		http
+			.post<PostTerritoryPoints>(`/points/${login}/free-points`, { body })
+			.then(({ body }) => body),
+
+	getFreePoints: ({ path: { login } }: GetFreePoints['request']) =>
+		http
+			.get<GetFreePoints>(`/points/${login}/free-points`)
+			.then(({ body }) => body),
+
+	getFreePointsHistory: ({
+		path: { login },
+	}: GetFreePointsHistory['request']) =>
+		http
+			.get<GetFreePointsHistory>(`/points/${login}/free-points/history`)
+			.then(({ body }) => body.map(convertFreePointChangeHistoryDto)),
+
+	postExperiencePoints: ({ body }: PostExperiencePoints['request']) =>
+		http
+			.post<PostExperiencePoints>(`/points/experience-points`, { body })
+			.then(({ body }) => body),
+
+	getExperiencePoints: () =>
+		http
+			.get<GetExperiencePoints>(`/points/experience-points`)
+			.then(({ body }) => body),
+
+	postTerritoryHours: ({ body }: PostTerritoryHours['request']) =>
+		http
+			.post<PostTerritoryHours>(`/points/territory-hours`, { body })
+			.then(({ body }) => body),
+
+	getTerritoryHours: () =>
+		http
+			.get<GetTerritoryHours>(`/points/territory-hours`)
+			.then(({ body }) => body),
 }

--- a/src/api-facade/api/apiSystemParameters.ts
+++ b/src/api-facade/api/apiSystemParameters.ts
@@ -1,0 +1,9 @@
+import { http } from '../http'
+import type { GetSystemParameter } from '../requests/system-parameters-requests.ts'
+
+export const apiSystemParameters = {
+	getSystemParameter: ({ path: { name } }: GetSystemParameter['request']) =>
+		http
+			.get<GetSystemParameter>(`/system-parameters/${name}`)
+			.then(({ body }) => body),
+}

--- a/src/api-facade/api/apiUsers.ts
+++ b/src/api-facade/api/apiUsers.ts
@@ -10,7 +10,7 @@ export const apiUsers = {
 		http.get<GetAllLogins>('/users/all/names').then(({ body }) => body),
 
 	postDisplayName: ({ body }: PostDisplayName['request']) =>
-		http.post('/users/display-name', { body }).then(({ body }) => body),
+		http.post('/users/display-name', { body }),
 
 	getDisplayName: () =>
 		http.get<GetDisplayName>('/users/display-name').then(({ body }) => body),

--- a/src/api-facade/api/apiWheelEffects.ts
+++ b/src/api-facade/api/apiWheelEffects.ts
@@ -1,7 +1,7 @@
 import type { WheelResult } from '../../types/wheelResult'
 import {
-	convertFreePointChangeResult,
 	convertRolledWheelEffectDto,
+	convertRolledWheelEffectHistoryDto,
 } from '../dto'
 import { http } from '../http'
 import type {
@@ -17,7 +17,9 @@ export const apiWheelEffects = {
 	getHistory: ({ path: { login } }: GetWheelEffectsHistory['request']) =>
 		http
 			.get<GetWheelEffectsHistory>(`/wheel-effects/${login}/history`)
-			.then(({ body: effects }) => effects.map(convertRolledWheelEffectDto)),
+			.then(({ body: effects }) =>
+				effects.map(convertRolledWheelEffectHistoryDto),
+			),
 
 	getAvailable: () =>
 		http
@@ -50,10 +52,5 @@ export const apiWheelEffects = {
 			.post<PostApplyWheelEffectRoll>('/wheel-effects/available/roll/apply', {
 				body,
 			})
-			.then(({ body: results }) =>
-				results.map((result) => ({
-					...result,
-					changeResult: convertFreePointChangeResult(result.changeResult),
-				})),
-			),
+			.then(({ body }) => body),
 }

--- a/src/api-facade/dto.ts
+++ b/src/api-facade/dto.ts
@@ -4,14 +4,14 @@ import type { Timer, TimerDto } from './models/timers-models'
 import type {
 	RolledWheelEffect,
 	RolledWheelEffectDto,
+	RolledWheelEffectHistory,
+	RolledWheelEffectHistoryDto,
 } from './models/wheel-effects-models'
 import type {
-	FreePointChangeResult,
-	FreePointChangeResultDto,
-	PointChangeResult,
-	PointChangeResultDto,
-	TerritoryPointChangeResult,
-	TerritoryPointChangeResultDto,
+	FreePointChangeHistory,
+	FreePointChangeHistoryDto,
+	TerritoryPointChangeHistory,
+	TerritoryPointChangeHistoryDto,
 } from './models/points-models'
 
 export type DtoStringToDate<
@@ -47,28 +47,30 @@ export const convertTimerDto = (timer: TimerDto): Timer => ({
 			: undefined,
 })
 
+export const convertTerritoryPointChangeHistoryDto = (
+	history: TerritoryPointChangeHistoryDto,
+): TerritoryPointChangeHistory => ({
+	...history,
+	changeDate: Temporal.Instant.from(history.changeDate),
+})
+
+export const convertFreePointChangeHistoryDto = (
+	history: FreePointChangeHistoryDto,
+): FreePointChangeHistory => ({
+	...history,
+	changeDate: Temporal.Instant.from(history.changeDate),
+})
+
+export const convertRolledWheelEffectHistoryDto = (
+	history: RolledWheelEffectHistoryDto,
+): RolledWheelEffectHistory => ({
+	...history,
+	rollDate: Temporal.Instant.from(history.rollDate),
+})
+
 export const convertRolledWheelEffectDto = (
 	effect: RolledWheelEffectDto,
 ): RolledWheelEffect => ({
 	...effect,
 	rollDate: Temporal.Instant.from(effect.rollDate),
 })
-
-const _convertPointChangeResult = <T extends PointChangeResultDto>(result: T) =>
-	({
-		...result,
-		changeDate: Temporal.Instant.from(result.changeDate),
-	}) satisfies PointChangeResult
-
-export const convertPointChangeResult: (
-	result: PointChangeResultDto,
-) => PointChangeResult = _convertPointChangeResult<PointChangeResultDto>
-
-export const convertTerritoryPointChangeResult: (
-	result: TerritoryPointChangeResultDto,
-) => TerritoryPointChangeResult =
-	_convertPointChangeResult<TerritoryPointChangeResultDto>
-
-export const convertFreePointChangeResult: (
-	result: FreePointChangeResultDto,
-) => FreePointChangeResult = _convertPointChangeResult<FreePointChangeResultDto>

--- a/src/api-facade/models/points-models.ts
+++ b/src/api-facade/models/points-models.ts
@@ -1,30 +1,22 @@
-import { type DtoStringToDate } from '../dto'
-
-export type Points = number
+import type { DtoStringToDate } from '../dto.ts'
 
 export type PointInfo = {
 	availableRolls: number
-	experiencePoints: Points
-	freePoints: Points
+	experiencePoints: number
+	freePoints: number
 	territoryHours: number
-	territoryPoints: Points
+	territoryPoints: number
 }
 
 export type PointChange = {
-	changeSource?: string
-	desiredChangeValue?: number
+	changeSource: string
+	desiredChangeValue: number
 }
 
-export type PointChangeResultDto = {
+export type PointChangeResult =  PointChange & {
 	actualChangeValue: number
-	changeDate: string
-	finalValue: Points
-} & PointChange
-
-export type PointChangeResult = DtoStringToDate<
-	PointChangeResultDto,
-	'changeDate'
->
+	finalValue: number
+}
 
 export enum TerritoryChangeSource {
 	ObtainingTerritory = 'territory-obtaining',
@@ -32,29 +24,43 @@ export enum TerritoryChangeSource {
 	Other = 'other',
 }
 
-export type TerritoryPointChangeResultDto = PointChangeResultDto & {
-	changeSource?: TerritoryChangeSource
+export type TerritoryPointChangeResult = PointChangeResult & {
+	changeSource: TerritoryChangeSource
 }
 
-export type TerritoryPointChangeResult = DtoStringToDate<
-	TerritoryPointChangeResultDto,
+export type TerritoryPointChangeHistoryDto = TerritoryPointChangeResult & {
+	changeDate: string
+	sourceLogin?: string
+}
+
+export type TerritoryPointChangeHistory = DtoStringToDate<
+	TerritoryPointChangeHistoryDto,
 	'changeDate'
 >
 
 export enum FreePointChangeSource {
-	OwnWheelEffect = 'own-wheel-effect',
-	OtherWheelEffect = 'other-wheel-effect',
+	WheelEffect = 'wheel-effect',
 	Quest = 'quest',
 	BaseTeleport = 'base-teleport',
 	Sandstorm = 'sandstorm',
 	Other = 'other',
 }
 
-export type FreePointChangeResultDto = PointChangeResultDto & {
+export type FreePointChange = PointChange & {
+	wheelEffectName?: string
+}
+
+export type FreePointChangeResult = PointChangeResult & {
 	changeSource: FreePointChangeSource
 }
 
-export type FreePointChangeResult = DtoStringToDate<
-	FreePointChangeResultDto,
+export type FreePointChangeHistoryDto = FreePointChangeResult & {
+	changeDate: string
+	sourceLogin?: string
+	wheelEffectName?: string
+}
+
+export type FreePointChangeHistory = DtoStringToDate<
+	FreePointChangeHistoryDto,
 	'changeDate'
 >

--- a/src/api-facade/models/system-parameters-models.ts
+++ b/src/api-facade/models/system-parameters-models.ts
@@ -1,0 +1,4 @@
+export type SystemParameter = {
+	name: string
+	value: string
+}

--- a/src/api-facade/models/wheel-effects-models.ts
+++ b/src/api-facade/models/wheel-effects-models.ts
@@ -5,10 +5,19 @@ export type WheelEffect = {
 	description?: string
 }
 
+export type RolledWheelEffectHistoryDto = WheelEffect & {
+	rollDate: string
+}
+
+export type RolledWheelEffectHistory = DtoStringToDate<
+	RolledWheelEffectHistoryDto,
+	'rollDate'
+>
+
 export type RolledWheelEffectDto = WheelEffect & {
 	rollDate: string
-	isApplied?: boolean
-	position?: number
+	isApplied: boolean
+	position: number
 }
 
 export type RolledWheelEffect = DtoStringToDate<

--- a/src/api-facade/requests/points-requests.ts
+++ b/src/api-facade/requests/points-requests.ts
@@ -1,9 +1,12 @@
 import type {
-	FreePointChangeResultDto,
+	FreePointChange,
+	FreePointChangeHistoryDto,
+	FreePointChangeResult,
 	PointChange,
-	PointChangeResultDto,
+	PointChangeResult,
 	PointInfo,
-	TerritoryPointChangeResultDto,
+	TerritoryPointChangeHistoryDto,
+	TerritoryPointChangeResult,
 } from '../models/points-models'
 
 export type GetPointsInfo = {
@@ -29,7 +32,7 @@ export type PostTerritoryPoints = {
 		}
 		body: PointChange
 	}
-	response: TerritoryPointChangeResultDto[]
+	response: TerritoryPointChangeResult
 }
 
 export type GetTerritoryPoints = {
@@ -47,17 +50,25 @@ export type GetTerritoryPointsHistory = {
 			login: string
 		}
 	}
-	response: TerritoryPointChangeResultDto
+	response: TerritoryPointChangeHistoryDto[]
 }
 
 export type PostFreePoints = {
 	request: {
-		body: PointChange
+		path: {
+			login: string
+		}
+		body: FreePointChange
 	}
-	response: FreePointChangeResultDto
+	response: FreePointChangeResult
 }
 
 export type GetFreePoints = {
+	request: {
+		path: {
+			login: string
+		}
+	}
 	response: number
 }
 
@@ -67,22 +78,17 @@ export type GetFreePointsHistory = {
 			login: string
 		}
 	}
-	response: FreePointChangeResultDto[]
+	response: FreePointChangeHistoryDto[]
 }
 
 export type PostExperiencePoints = {
 	request: {
 		body: PointChange
 	}
-	response: PointChangeResultDto
+	response: PointChangeResult
 }
 
 export type GetExperiencePoints = {
-	// request: {
-	// 	path: {
-	// 		login: string
-	// 	}
-	// }
 	response: number
 }
 
@@ -90,14 +96,9 @@ export type PostTerritoryHours = {
 	request: {
 		body: PointChange
 	}
-	response: PointChangeResultDto
+	response: PointChangeResult
 }
 
 export type GetTerritoryHours = {
-	// request: {
-	// 	path: {
-	// 		login: string
-	// 	}
-	// }
 	response: number
 }

--- a/src/api-facade/requests/system-parameters-requests.ts
+++ b/src/api-facade/requests/system-parameters-requests.ts
@@ -1,0 +1,10 @@
+import type { SystemParameter } from '../models/system-parameters-models.ts'
+
+export type GetSystemParameter = {
+	request: {
+		path: {
+			name: string
+		}
+	}
+	response: SystemParameter
+}

--- a/src/api-facade/requests/wheel-effects-requests.ts
+++ b/src/api-facade/requests/wheel-effects-requests.ts
@@ -1,7 +1,11 @@
 import type { WheelResultDto } from '../../types/wheelResult'
-import type { FreePointChangeResultDto, PointChange } from '../models/points-models'
+import type {
+	FreePointChangeResult,
+	PointChange,
+} from '../models/points-models'
 import type {
 	RolledWheelEffectDto,
+	RolledWheelEffectHistoryDto,
 	WheelEffect,
 } from '../models/wheel-effects-models'
 
@@ -11,7 +15,7 @@ export type GetWheelEffectsHistory = {
 			login: string
 		}
 	}
-	response: RolledWheelEffectDto[]
+	response: RolledWheelEffectHistoryDto[]
 }
 
 export type GetWheelEffectsAvailable = {
@@ -19,7 +23,7 @@ export type GetWheelEffectsAvailable = {
 }
 
 export type PostRollWheelEffect = {
-	response: WheelResultDto
+	response: RolledWheelEffectDto[]
 }
 
 export type GetAvailableWheelEffectCount = {
@@ -33,12 +37,15 @@ export type GetLastRolledWheelEffects = {
 export type PostApplyWheelEffectRoll = {
 	request: {
 		body: {
-			login: string
-			pointChange: PointChange
-		}[]
+			pointChanges: {
+				login: string
+				pointChange: PointChange
+			}[]
+			wheelEffectName: string
+		}
 	}
 	response: {
 		login: string
-		changeResult: FreePointChangeResultDto
+		changeResult: FreePointChangeResult
 	}[]
 }

--- a/src/stores/api/apiTimerStore.ts
+++ b/src/stores/api/apiTimerStore.ts
@@ -18,6 +18,7 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 	const durationTotal = ref(Temporal.Duration.from(DEFAULT_DURATION))
 
 	const currentLoading = useLoading()
+	const currentFromUserLoading = useLoading()
 	const actionLoading = useLoading()
 
 	const lastActionDate = ref<Temporal.Instant | null>(null)
@@ -104,7 +105,7 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 		if (!canPause.value) return Promise.reject()
 		if (actionLoading.state.value === LoadingState.LOADING) return
 
-		actionLoading.state.value = LoadingState.LOADING
+		currentFromUserLoading.state.value = LoadingState.LOADING
 
 		const prevLastActionDate = lastActionDate.value
 		const prevState = state.value


### PR DESCRIPTION
## Summary

- Add territory-points, free-points, experience-points, territory-hours endpoints to `apiPoints`
- Add `apiSystemParameters` module with `getSystemParameter`
- Split history DTO types (with `changeDate`) from result types in points and wheel-effects models
- Rename `FreePointChangeSource`: `OwnWheelEffect`/`OtherWheelEffect` → `WheelEffect`
- Add `wheelEffectName` to `PostApplyWheelEffectRoll` request body
- Add `currentFromUserLoading` state to `apiTimerStore`