### PR TITLE
fix: wishlist count hint shows 0 or negative numbers

### DIFF
--- a/src/views/Games/GamesView.vue
+++ b/src/views/Games/GamesView.vue
@@ -10,12 +10,7 @@ import AddGameForm from './components/AddGameForm.vue'
 
 const gameStore = useFeatureGameStore()
 
-const { current, canRoll, wishlist } = storeToRefs(gameStore)
-const showCountHint = ref(false)
-
-gameStore.getWishlistState.on([LoadingStatus.LOADED]).then(() => {
-	showCountHint.value = !gameStore.enoughGamesInWishlist
-})
+const { current, canRoll, wishlist, enoughGamesInWishlist } = storeToRefs(gameStore)
 
 const rollText = ref('Загрузка...')
 
@@ -103,7 +98,7 @@ onMounted(() => {
 			<div class="container">
 				<AddGameForm />
 
-				<p class="hint" v-if="showCountHint">
+				<p class="hint" v-if="!enoughGamesInWishlist">
 					Чтобы крутить следующую игру, надо 6 игр, нужно ещё
 					{{ 6 - wishlist.length }}.
 				</p>


### PR DESCRIPTION
## Summary

- `showCountHint` was a `ref` set once on wishlist load, so it stayed `true` after the 6th game was added
- Template computed `6 - wishlist.length` against a stale flag, producing 0 or negative values
- Fixed by using `enoughGamesInWishlist` computed directly from the store — now reacts to every wishlist change

Closes #32