### PR TITLE
feat: Wheel effect cards improvements

### DIFF
--- a/src/api-facade/models/points-models.ts
+++ b/src/api-facade/models/points-models.ts
@@ -13,9 +13,14 @@ export type PointChange = {
 	desiredChangeValue: number
 }
 
-export type PointChangeResult =  PointChange & {
+export type PointChangeResult = PointChange & {
 	actualChangeValue: number
 	finalValue: number
+}
+
+export type PointChangeWithLogin = {
+	login: string
+	pointChange: PointChange
 }
 
 export enum TerritoryChangeSource {

--- a/src/api-facade/requests/wheel-effects-requests.ts
+++ b/src/api-facade/requests/wheel-effects-requests.ts
@@ -1,7 +1,7 @@
 import type { WheelResult } from '../../types/wheelResult.ts'
 import type {
 	FreePointChangeResult,
-	PointChange,
+	PointChangeWithLogin,
 } from '../models/points-models'
 import type {
 	RolledWheelEffectDto,
@@ -37,10 +37,7 @@ export type GetLastRolledWheelEffects = {
 export type PostApplyWheelEffectRoll = {
 	request: {
 		body: {
-			pointChanges: {
-				login: string
-				pointChange: PointChange
-			}[]
+			pointChanges: PointChangeWithLogin[]
 			wheelEffectName: string
 		}
 	}

--- a/src/stores/api/apiWheelStore.ts
+++ b/src/stores/api/apiWheelStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 import { api } from '../../api-facade/api'
 import type {
 	RolledWheelEffectHistory,
@@ -16,8 +16,6 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 	>({})
 	const availableEffects = ref<WheelEffect[] | null>(null)
 	const currentEffects = ref<WheelResult | null>(null)
-
-	const pendingRoll = computed(() => availableRollCount.value !== 0)
 
 	const [getHistory, getHistoryState] = withLoading(
 		async (status, login: string) => {
@@ -59,7 +57,7 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 	)
 
 	const [roll, rollState] = withLoading(async (status) => {
-		if (!pendingRoll.value) {
+		if (availableRollCount.value <= 0) {
 			return Promise.reject('No pending rolls')
 		}
 		if (status.value === LoadingStatus.LOADING) return
@@ -70,6 +68,7 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 			.postRoll()
 			.then((effects) => {
 				currentEffects.value = effects
+				availableRollCount.value--
 				status.value = LoadingStatus.LOADED
 			})
 			.catch((e) => {
@@ -125,8 +124,6 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 		effectsHistory,
 		availableEffects,
 		currentEffects,
-
-		pendingRoll,
 
 		getHistory,
 		getHistoryState,

--- a/src/stores/api/apiWheelStore.ts
+++ b/src/stores/api/apiWheelStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { api } from '../../api-facade/api'
-import { FreePointChangeSource } from '../../api-facade/models/points-models'
+import { PointChangeWithLogin } from '../../api-facade/models/points-models'
 import type {
 	RolledWheelEffectHistory,
 	WheelEffect,
@@ -119,7 +119,7 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 		async (
 			status,
 			effectName: string,
-			changes: { login: string; desiredChangeValue: number }[],
+			pointChanges: PointChangeWithLogin[],
 		) => {
 			if (status.value === LoadingStatus.LOADING) return
 
@@ -129,17 +129,13 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 				.postApplyRoll({
 					body: {
 						wheelEffectName: effectName,
-						pointChanges: changes.map(({ login, desiredChangeValue }) => ({
-							login,
-							pointChange: {
-								changeSource: FreePointChangeSource.WheelEffect,
-								desiredChangeValue,
-							},
-						})),
+						pointChanges: pointChanges,
 					},
 				})
 				.then(() => {
-					const effect = currentEffects.value?.find((e) => e.name === effectName)
+					const effect = currentEffects.value?.find(
+						(e) => e.name === effectName,
+					)
 					if (effect) effect.isApplied = true
 					status.value = LoadingStatus.LOADED
 				})

--- a/src/stores/api/apiWheelStore.ts
+++ b/src/stores/api/apiWheelStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { api } from '../../api-facade/api'
+import { FreePointChangeSource } from '../../api-facade/models/points-models'
 import type {
 	RolledWheelEffectHistory,
 	WheelEffect,
@@ -114,10 +115,40 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 			})
 	})
 
-	// const applyRoll = async () => {
-	//  @todo remove applied from available
-	// 	await api.wheelEffects.postApplyRoll()
-	// }
+	const [applyRoll, applyRollState] = withLoading(
+		async (
+			status,
+			effectName: string,
+			changes: { login: string; desiredChangeValue: number }[],
+		) => {
+			if (status.value === LoadingStatus.LOADING) return
+
+			status.value = LoadingStatus.LOADING
+
+			await api.wheelEffects
+				.postApplyRoll({
+					body: {
+						wheelEffectName: effectName,
+						pointChanges: changes.map(({ login, desiredChangeValue }) => ({
+							login,
+							pointChange: {
+								changeSource: FreePointChangeSource.WheelEffect,
+								desiredChangeValue,
+							},
+						})),
+					},
+				})
+				.then(() => {
+					const effect = currentEffects.value?.find((e) => e.name === effectName)
+					if (effect) effect.isApplied = true
+					status.value = LoadingStatus.LOADED
+				})
+				.catch((e) => {
+					status.value = LoadingStatus.ERROR
+					throw e
+				})
+		},
+	)
 
 	return {
 		availableRollCount,
@@ -140,7 +171,7 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 		getLastRoll,
 		getLastRollState,
 
-		// applyRoll,
-		// applyRollState,
+		applyRoll,
+		applyRollState,
 	}
 })

--- a/src/stores/feature/featureWheelStore.ts
+++ b/src/stores/feature/featureWheelStore.ts
@@ -3,18 +3,20 @@ import { computed, watch } from 'vue'
 import { TimerState } from '../../api-facade/models/timers-models'
 import { StoreName } from '../../enums/storeName'
 import { useApiTimerStore } from '../api/apiTimerStore'
+import { useApiUserStore } from '../api/apiUserStore'
 import { useApiWheelStore } from '../api/apiWheelStore'
 import { useAuthStore } from '../authStore'
 
 export const useFeatureWheelStore = defineStore(StoreName.FeatureWheel, () => {
 	const wheelStore = useApiWheelStore()
+	const userStore = useApiUserStore()
 	const timerStore = useApiTimerStore()
 	const authStore = useAuthStore()
 
 	const currentEffects = computed(() => wheelStore.currentEffects)
 	const availableEffects = computed(() => wheelStore.availableEffects)
 
-	const pendingRoll = computed(() => wheelStore.pendingRoll)
+	const availableRollCount = computed(() => wheelStore.availableRollCount)
 
 	const getHistory = async (login: string | undefined = authStore.login) => {
 		if (!login) return Promise.reject('No current user login')
@@ -52,7 +54,7 @@ export const useFeatureWheelStore = defineStore(StoreName.FeatureWheel, () => {
 		currentEffects,
 		availableEffects,
 
-		pendingRoll,
+		availableRollCount,
 
 		init,
 
@@ -67,5 +69,12 @@ export const useFeatureWheelStore = defineStore(StoreName.FeatureWheel, () => {
 
 		getLastRoll,
 		getLastRollState: wheelStore.getLastRollState,
+
+		users: computed(() => userStore.users),
+		getAllUsers: userStore.getAllUsers,
+		getAllUsersState: userStore.getAllUsersState,
+
+		applyRoll: wheelStore.applyRoll,
+		applyRollState: wheelStore.applyRollState,
 	}
 })

--- a/src/views/WheelRolls/WheelRollsView.vue
+++ b/src/views/WheelRolls/WheelRollsView.vue
@@ -25,7 +25,7 @@ const getRandomItems = <T,>(collection: T[], count: number = 1): T[] => {
 
 const visibleEffects = computed(() => {
 	if (wheelStore.currentEffects) {
-		return wheelStore.currentEffects
+		return [...wheelStore.currentEffects].sort((a, b) => a.position - b.position)
 	}
 
 	if (wheelStore.availableEffects) {

--- a/src/views/WheelRolls/WheelRollsView.vue
+++ b/src/views/WheelRolls/WheelRollsView.vue
@@ -5,6 +5,7 @@ import { computed, onMounted, ref } from 'vue'
 import { funnyEffects } from './constants/funnyEffects'
 import UiView from '../../components/ui/UiView.vue'
 import type { RolledWheelEffectDto } from '../../api-facade/models/wheel-effects-models'
+import { FreePointChangeSource } from '../../api-facade/models/points-models'
 
 const wheelStore = useFeatureWheelStore()
 
@@ -65,7 +66,13 @@ const submitApply = async () => {
 
 	const changes = Object.entries(pointChanges.value)
 		.filter(([, value]) => value !== 0)
-		.map(([login, desiredChangeValue]) => ({ login, desiredChangeValue }))
+		.map(([login, desiredChangeValue]) => ({
+			login,
+			pointChange: {
+				changeSource: FreePointChangeSource.WheelEffect,
+				desiredChangeValue,
+			},
+		}))
 
 	await wheelStore.applyRoll(selectedEffect.value.name, changes)
 	showApplyForm.value = false

--- a/src/views/WheelRolls/WheelRollsView.vue
+++ b/src/views/WheelRolls/WheelRollsView.vue
@@ -5,9 +5,6 @@ import { computed, onMounted, ref } from 'vue'
 import { funnyEffects } from './constants/funnyEffects'
 import UiView from '../../components/ui/UiView.vue'
 import type { RolledWheelEffectDto } from '../../api-facade/models/wheel-effects-models'
-import type { Login } from '../../api-facade/models/users-models'
-import { FreePointChangeSource } from '../../api-facade/models/points-models'
-import { api } from '../../api-facade/api'
 
 const wheelStore = useFeatureWheelStore()
 
@@ -42,22 +39,17 @@ const onRollButtonClick = () => {
 
 const selectedEffect = ref<RolledWheelEffectDto | null>(null)
 const showApplyForm = ref(false)
-const players = ref<Login[]>([])
 const pointChanges = ref<Record<string, number>>({})
-const applying = ref(false)
 
 const closeModal = () => {
 	selectedEffect.value = null
 	showApplyForm.value = false
 }
 
-const openApplyForm = async () => {
-	if (!players.value.length) {
-		players.value = await api.users.getAllNames()
-		pointChanges.value = Object.fromEntries(
-			players.value.map((p) => [p.login, 0]),
-		)
-	}
+const openApplyForm = () => {
+	pointChanges.value = Object.fromEntries(
+		(wheelStore.users ?? []).map((user) => [user.login, 0]),
+	)
 	showApplyForm.value = true
 }
 
@@ -73,32 +65,16 @@ const submitApply = async () => {
 
 	const changes = Object.entries(pointChanges.value)
 		.filter(([, value]) => value !== 0)
-		.map(([login, desiredChangeValue]) => ({
-			login,
-			pointChange: {
-				changeSource: FreePointChangeSource.WheelEffect,
-				desiredChangeValue,
-			},
-		}))
+		.map(([login, desiredChangeValue]) => ({ login, desiredChangeValue }))
 
-	applying.value = true
-	try {
-		await api.wheelEffects.postApplyRoll({
-			body: {
-				wheelEffectName: selectedEffect.value.name,
-				pointChanges: changes,
-			},
-		})
-		selectedEffect.value.isApplied = true
-		showApplyForm.value = false
-	} finally {
-		applying.value = false
-	}
+	await wheelStore.applyRoll(selectedEffect.value.name, changes)
+	showApplyForm.value = false
 }
 
 onMounted(() => {
 	wheelStore.getLastRoll()
 	wheelStore.getAvailableEffects()
+	wheelStore.getAllUsers()
 })
 </script>
 
@@ -158,29 +134,29 @@ onMounted(() => {
 
 					<template v-else>
 						<h2 class="modal-title">Применить: {{ selectedEffect.name }}</h2>
-						<div class="players-list">
+						<div class="users-list">
 							<div
-								v-for="player in players"
-								:key="player.login"
-								class="player-row"
+								v-for="user in wheelStore.users"
+								:key="user.login"
+								class="user-row"
 							>
-								<span class="player-name">{{
-									player.displayName ?? player.login
+								<span class="user-name">{{
+									user.displayName ?? user.login
 								}}</span>
 								<input
 									class="point-input"
 									type="number"
 									min="-100"
 									max="100"
-									:value="pointChanges[player.login]"
-									@input="onPointInput(player.login, $event)"
+									:value="pointChanges[user.login]"
+									@input="onPointInput(user.login, $event)"
 								/>
 							</div>
 						</div>
 						<div class="modal-actions">
 							<button
 								class="modal-button modal-button--primary"
-								:disabled="applying"
+								:disabled="wheelStore.applyRollState.isLoading"
 								@click="submitApply"
 							>
 								Подтвердить
@@ -330,7 +306,7 @@ onMounted(() => {
 	background-color: #2563eb;
 }
 
-.players-list {
+.users-list {
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
@@ -338,14 +314,14 @@ onMounted(() => {
 	overflow-y: auto;
 }
 
-.player-row {
+.user-row {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: 12px;
 }
 
-.player-name {
+.user-name {
 	flex: 1;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/src/views/WheelRolls/WheelRollsView.vue
+++ b/src/views/WheelRolls/WheelRollsView.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import UiButton from '../../components/ui/UiButton.vue'
 import { useFeatureWheelStore } from '../../stores/feature/featureWheelStore'
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { funnyEffects } from './constants/funnyEffects'
 import UiView from '../../components/ui/UiView.vue'
+import type { WheelEffect } from '../../api-facade/models/wheel-effects-models'
 
 const wheelStore = useFeatureWheelStore()
 
@@ -38,6 +39,8 @@ const onRollButtonClick = () => {
 	wheelStore.roll()
 }
 
+const selectedEffect = ref<WheelEffect | null>(null)
+
 onMounted(() => {
 	wheelStore.getLastRoll()
 	wheelStore.getAvailableEffects()
@@ -50,8 +53,13 @@ onMounted(() => {
 			<h1 class="title">Роллы</h1>
 
 			<div class="effects-grid">
-				<div class="effect-card" :key="effect.name" v-for="effect in visibleEffects">
-					{{ effect.name }}
+				<div
+					class="effect-card"
+					:key="effect.name"
+					v-for="effect in visibleEffects"
+					@click="selectedEffect = effect"
+				>
+					<span class="effect-name">{{ effect.name }}</span>
 				</div>
 			</div>
 
@@ -59,6 +67,25 @@ onMounted(() => {
 				Прокрутить
 			</UiButton>
 		</div>
+
+		<Teleport to="body">
+			<div
+				v-if="selectedEffect"
+				class="modal-overlay"
+				@click.self="selectedEffect = null"
+			>
+				<div class="modal">
+					<h2 class="modal-title">{{ selectedEffect.name }}</h2>
+					<p v-if="selectedEffect.description" class="modal-description">
+						{{ selectedEffect.description }}
+					</p>
+					<p v-else class="modal-empty">Описание отсутствует</p>
+					<button class="modal-close" @click="selectedEffect = null">
+						Закрыть
+					</button>
+				</div>
+			</div>
+		</Teleport>
 	</UiView>
 </template>
 
@@ -92,14 +119,77 @@ onMounted(() => {
 }
 
 .effect-card {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 8px;
 	height: 160px;
 	width: 120px;
 	border: 1px solid #64748b;
+	overflow: hidden;
+	cursor: pointer;
+}
+
+.effect-card:hover {
+	background-color: #f8fafc;
+}
+
+.effect-name {
+	font-weight: 600;
 }
 
 .roll-button {
 	height: 56px;
 	width: 224px;
 	justify-self: center;
+}
+
+.modal-overlay {
+	position: fixed;
+	inset: 0;
+	background-color: rgba(0, 0, 0, 0.4);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 100;
+}
+
+.modal {
+	background: #fff;
+	border-radius: 8px;
+	padding: 24px;
+	max-width: 400px;
+	width: 90%;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.modal-title {
+	font-size: 1.25rem;
+	font-weight: 600;
+}
+
+.modal-description {
+	color: #334155;
+	line-height: 1.6;
+}
+
+.modal-empty {
+	color: #94a3b8;
+	font-style: italic;
+}
+
+.modal-close {
+	align-self: flex-end;
+	padding: 6px 16px;
+	border: 1px solid #64748b;
+	border-radius: 4px;
+	cursor: pointer;
+	background: transparent;
+}
+
+.modal-close:hover {
+	background-color: #f1f5f9;
 }
 </style>

--- a/src/views/WheelRolls/WheelRollsView.vue
+++ b/src/views/WheelRolls/WheelRollsView.vue
@@ -4,7 +4,7 @@ import { useFeatureWheelStore } from '../../stores/feature/featureWheelStore'
 import { computed, onMounted, ref } from 'vue'
 import { funnyEffects } from './constants/funnyEffects'
 import UiView from '../../components/ui/UiView.vue'
-import type { WheelEffect } from '../../api-facade/models/wheel-effects-models'
+import type { RolledWheelEffectDto } from '../../api-facade/models/wheel-effects-models'
 
 const wheelStore = useFeatureWheelStore()
 
@@ -28,10 +28,6 @@ const visibleEffects = computed(() => {
 		return [...wheelStore.currentEffects].sort((a, b) => a.position - b.position)
 	}
 
-	if (wheelStore.availableEffects) {
-		return getRandomItems(wheelStore.availableEffects, 5)
-	}
-
 	return getRandomItems(funnyEffects, 5)
 })
 
@@ -39,7 +35,7 @@ const onRollButtonClick = () => {
 	wheelStore.roll()
 }
 
-const selectedEffect = ref<WheelEffect | null>(null)
+const selectedEffect = ref<RolledWheelEffectDto | null>(null)
 
 onMounted(() => {
 	wheelStore.getLastRoll()
@@ -60,6 +56,10 @@ onMounted(() => {
 					@click="selectedEffect = effect"
 				>
 					<span class="effect-name">{{ effect.name }}</span>
+					<label class="effect-applied" @click.stop>
+						<input type="checkbox" :checked="effect.isApplied" disabled />
+						Применён
+					</label>
 				</div>
 			</div>
 
@@ -80,6 +80,10 @@ onMounted(() => {
 						{{ selectedEffect.description }}
 					</p>
 					<p v-else class="modal-empty">Описание отсутствует</p>
+					<label class="effect-applied">
+						<input type="checkbox" :checked="selectedEffect.isApplied" disabled />
+						Применён
+					</label>
 					<button class="modal-close" @click="selectedEffect = null">
 						Закрыть
 					</button>
@@ -136,6 +140,16 @@ onMounted(() => {
 
 .effect-name {
 	font-weight: 600;
+}
+
+.effect-applied {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 0.75rem;
+	color: #64748b;
+	margin-top: auto;
+	cursor: default;
 }
 
 .roll-button {

--- a/src/views/WheelRolls/WheelRollsView.vue
+++ b/src/views/WheelRolls/WheelRollsView.vue
@@ -122,7 +122,7 @@ onMounted(() => {
 				</div>
 			</div>
 
-			<UiButton class="roll-button" @click="onRollButtonClick">
+			<UiButton class="roll-button" :disabled="!wheelStore.availableRollCount" @click="onRollButtonClick">
 				Прокрутить
 			</UiButton>
 		</div>

--- a/src/views/WheelRolls/WheelRollsView.vue
+++ b/src/views/WheelRolls/WheelRollsView.vue
@@ -5,6 +5,9 @@ import { computed, onMounted, ref } from 'vue'
 import { funnyEffects } from './constants/funnyEffects'
 import UiView from '../../components/ui/UiView.vue'
 import type { RolledWheelEffectDto } from '../../api-facade/models/wheel-effects-models'
+import type { Login } from '../../api-facade/models/users-models'
+import { FreePointChangeSource } from '../../api-facade/models/points-models'
+import { api } from '../../api-facade/api'
 
 const wheelStore = useFeatureWheelStore()
 
@@ -25,7 +28,9 @@ const getRandomItems = <T,>(collection: T[], count: number = 1): T[] => {
 
 const visibleEffects = computed(() => {
 	if (wheelStore.currentEffects) {
-		return [...wheelStore.currentEffects].sort((a, b) => a.position - b.position)
+		return [...wheelStore.currentEffects].sort(
+			(a, b) => a.position - b.position,
+		)
 	}
 
 	return getRandomItems(funnyEffects, 5)
@@ -36,6 +41,60 @@ const onRollButtonClick = () => {
 }
 
 const selectedEffect = ref<RolledWheelEffectDto | null>(null)
+const showApplyForm = ref(false)
+const players = ref<Login[]>([])
+const pointChanges = ref<Record<string, number>>({})
+const applying = ref(false)
+
+const closeModal = () => {
+	selectedEffect.value = null
+	showApplyForm.value = false
+}
+
+const openApplyForm = async () => {
+	if (!players.value.length) {
+		players.value = await api.users.getAllNames()
+		pointChanges.value = Object.fromEntries(
+			players.value.map((p) => [p.login, 0]),
+		)
+	}
+	showApplyForm.value = true
+}
+
+const clamp = (value: number) => Math.min(100, Math.max(-100, value))
+
+const onPointInput = (login: string, event: Event) => {
+	const raw = Number((event.target as HTMLInputElement).value)
+	pointChanges.value[login] = clamp(isNaN(raw) ? 0 : raw)
+}
+
+const submitApply = async () => {
+	if (!selectedEffect.value) return
+
+	const changes = Object.entries(pointChanges.value)
+		.filter(([, value]) => value !== 0)
+		.map(([login, desiredChangeValue]) => ({
+			login,
+			pointChange: {
+				changeSource: FreePointChangeSource.WheelEffect,
+				desiredChangeValue,
+			},
+		}))
+
+	applying.value = true
+	try {
+		await api.wheelEffects.postApplyRoll({
+			body: {
+				wheelEffectName: selectedEffect.value.name,
+				pointChanges: changes,
+			},
+		})
+		selectedEffect.value.isApplied = true
+		showApplyForm.value = false
+	} finally {
+		applying.value = false
+	}
+}
 
 onMounted(() => {
 	wheelStore.getLastRoll()
@@ -69,24 +128,68 @@ onMounted(() => {
 		</div>
 
 		<Teleport to="body">
-			<div
-				v-if="selectedEffect"
-				class="modal-overlay"
-				@click.self="selectedEffect = null"
-			>
+			<div v-if="selectedEffect" class="modal-overlay" @click.self="closeModal">
 				<div class="modal">
-					<h2 class="modal-title">{{ selectedEffect.name }}</h2>
-					<p v-if="selectedEffect.description" class="modal-description">
-						{{ selectedEffect.description }}
-					</p>
-					<p v-else class="modal-empty">Описание отсутствует</p>
-					<label class="effect-applied">
-						<input type="checkbox" :checked="selectedEffect.isApplied" disabled />
-						Применён
-					</label>
-					<button class="modal-close" @click="selectedEffect = null">
-						Закрыть
-					</button>
+					<template v-if="!showApplyForm">
+						<h2 class="modal-title">{{ selectedEffect.name }}</h2>
+						<p v-if="selectedEffect.description" class="modal-description">
+							{{ selectedEffect.description }}
+						</p>
+						<p v-else class="modal-empty">Описание отсутствует</p>
+						<label class="effect-applied">
+							<input
+								type="checkbox"
+								:checked="selectedEffect.isApplied"
+								disabled
+							/>
+							Применён
+						</label>
+						<div class="modal-actions">
+							<button
+								v-if="!selectedEffect.isApplied"
+								class="modal-button modal-button--primary"
+								@click="openApplyForm"
+							>
+								Применить
+							</button>
+							<button class="modal-button" @click="closeModal">Закрыть</button>
+						</div>
+					</template>
+
+					<template v-else>
+						<h2 class="modal-title">Применить: {{ selectedEffect.name }}</h2>
+						<div class="players-list">
+							<div
+								v-for="player in players"
+								:key="player.login"
+								class="player-row"
+							>
+								<span class="player-name">{{
+									player.displayName ?? player.login
+								}}</span>
+								<input
+									class="point-input"
+									type="number"
+									min="-100"
+									max="100"
+									:value="pointChanges[player.login]"
+									@input="onPointInput(player.login, $event)"
+								/>
+							</div>
+						</div>
+						<div class="modal-actions">
+							<button
+								class="modal-button modal-button--primary"
+								:disabled="applying"
+								@click="submitApply"
+							>
+								Подтвердить
+							</button>
+							<button class="modal-button" @click="showApplyForm = false">
+								Назад
+							</button>
+						</div>
+					</template>
 				</div>
 			</div>
 		</Teleport>
@@ -194,8 +297,13 @@ onMounted(() => {
 	font-style: italic;
 }
 
-.modal-close {
-	align-self: flex-end;
+.modal-actions {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-end;
+}
+
+.modal-button {
 	padding: 6px 16px;
 	border: 1px solid #64748b;
 	border-radius: 4px;
@@ -203,7 +311,52 @@ onMounted(() => {
 	background: transparent;
 }
 
-.modal-close:hover {
+.modal-button:hover:not(:disabled) {
 	background-color: #f1f5f9;
+}
+
+.modal-button:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.modal-button--primary {
+	background-color: #3b82f6;
+	border-color: #3b82f6;
+	color: #fff;
+}
+
+.modal-button--primary:hover:not(:disabled) {
+	background-color: #2563eb;
+}
+
+.players-list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-height: 300px;
+	overflow-y: auto;
+}
+
+.player-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.player-name {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.point-input {
+	width: 72px;
+	padding: 4px 8px;
+	border: 1px solid #cbd5e1;
+	border-radius: 4px;
+	text-align: right;
 }
 </style>

--- a/src/views/WheelRolls/constants/funnyEffects.ts
+++ b/src/views/WheelRolls/constants/funnyEffects.ts
@@ -1,15 +1,15 @@
-import type { WheelEffect } from '../../../api-facade/models/wheel-effects-models'
+import type { RolledWheelEffectDto } from '../../../api-facade/models/wheel-effects-models'
 
 /** just mock effects as a stub before normal ones load */
-export const funnyEffects: WheelEffect[] = [
-	'Смешной эффект 1',
-	'Смешной эффект 2',
-	'Смешной эффект 3',
-	'Смешной эффект 4',
-	'Смешной эффект 5',
-	'Смешной эффект 6',
-	'Смешной эффект 7',
-	'Смешной эффект 8',
-	'Смешной эффект 9',
-	'Смешной эффект 10',
-].map((name) => ({ name }))
+export const funnyEffects: RolledWheelEffectDto[] = [
+	{ name: 'Смешной эффект 1', isApplied: false, position: 1 },
+	{ name: 'Смешной эффект 2', isApplied: false, position: 2 },
+	{ name: 'Смешной эффект 3', isApplied: false, position: 3 },
+	{ name: 'Смешной эффект 4', isApplied: false, position: 4 },
+	{ name: 'Смешной эффект 5', isApplied: false, position: 5 },
+	{ name: 'Смешной эффект 6', isApplied: false, position: 6 },
+	{ name: 'Смешной эффект 7', isApplied: false, position: 7 },
+	{ name: 'Смешной эффект 8', isApplied: false, position: 8 },
+	{ name: 'Смешной эффект 9', isApplied: false, position: 9 },
+	{ name: 'Смешной эффект 10', isApplied: false, position: 10 },
+]


### PR DESCRIPTION
## Summary

- Added modal popup with full effect description on card click
- Cards are sorted by `position` field
- Added `isApplied` checkbox to effect cards and modal info view
- Added apply form in modal: user list with point change inputs (clamped to −100..100), checkboxes update on successful response
- Roll button disabled when `availableRollCount` is 0; count decrements after successful roll
- Moved apply logic (`postApplyRoll`, `FreePointChangeSource`) to `apiWheelStore`; users fetched via `featureWheelStore`