### PR TITLE
fix: Resolve TypeScript compiler errors

### DIFF
--- a/src/api-facade/dto-types.ts
+++ b/src/api-facade/dto-types.ts
@@ -1,0 +1,15 @@
+import type { Temporal } from '@js-temporal/polyfill'
+
+export type DtoStringToDate<
+	Dto extends object,
+	DateFields extends keyof Dto,
+> = {
+	[K in keyof Dto]: K extends DateFields ? Temporal.Instant : Dto[K]
+}
+
+export type DtoStringToDuration<
+	Dto extends object,
+	DurationFields extends keyof Dto,
+> = {
+	[K in keyof Dto]: K extends DurationFields ? Temporal.Duration : Dto[K]
+}

--- a/src/api-facade/dto.ts
+++ b/src/api-facade/dto.ts
@@ -12,20 +12,6 @@ import type {
 	TerritoryPointChangeHistoryDto,
 } from './models/points-models'
 
-export type DtoStringToDate<
-	Dto extends object,
-	DateFields extends keyof Dto,
-> = {
-	[K in keyof Dto]: K extends DateFields ? Temporal.Instant : Dto[K]
-}
-
-export type DtoStringToDuration<
-	Dto extends object,
-	DurationFields extends keyof Dto,
-> = {
-	[K in keyof Dto]: K extends DurationFields ? Temporal.Duration : Dto[K]
-}
-
 export const convertGameDto = (game: CurrentGameDto): CurrentGame => ({
 	...game,
 	finishDate:
@@ -39,10 +25,7 @@ export const convertTimerDto = (timer: TimerDto): Timer => ({
 	...timer,
 	duration: Temporal.Duration.from(timer.duration),
 	remainingTime: Temporal.Duration.from(timer.remainingTime),
-	lastActionDate:
-		timer.lastActionDate !== undefined
-			? Temporal.Instant.from(timer.lastActionDate)
-			: undefined,
+	lastActionDate: Temporal.Instant.from(timer.lastActionDate),
 })
 
 export const convertTerritoryPointChangeHistoryDto = (

--- a/src/api-facade/models/games-models.ts
+++ b/src/api-facade/models/games-models.ts
@@ -1,4 +1,4 @@
-import { type DtoStringToDate, type DtoStringToDuration } from '../dto'
+import { type DtoStringToDate, type DtoStringToDuration } from '../dto-types'
 
 export type WishlistedGame = {
 	name: string

--- a/src/api-facade/models/points-models.ts
+++ b/src/api-facade/models/points-models.ts
@@ -1,4 +1,4 @@
-import type { DtoStringToDate } from '../dto.ts'
+import type { DtoStringToDate } from '../dto-types'
 
 export type PointInfo = {
 	availableRolls: number

--- a/src/api-facade/models/timers-models.ts
+++ b/src/api-facade/models/timers-models.ts
@@ -1,4 +1,4 @@
-import { type DtoStringToDate, type DtoStringToDuration } from '../dto'
+import { type DtoStringToDate, type DtoStringToDuration } from '../dto-types'
 
 export enum TimerState {
 	Created = 'created',

--- a/src/api-facade/models/wheel-effects-models.ts
+++ b/src/api-facade/models/wheel-effects-models.ts
@@ -1,4 +1,4 @@
-import { type DtoStringToDate } from '../dto'
+import { type DtoStringToDate } from '../dto-types'
 
 export type WheelEffect = {
 	name: string

--- a/src/stores/feature/featureGameStore.ts
+++ b/src/stores/feature/featureGameStore.ts
@@ -30,7 +30,7 @@ export const useFeatureGameStore = defineStore(StoreName.FeatureGame, () => {
 	const enoughGamesInWishlist = computed(
 		() =>
 			wishlist.value.length >=
-			systemParametersStore.minimumNumberOfWishlistGames.value,
+			systemParametersStore.minimumNumberOfWishlistGames,
 	)
 	const currentGameIsFinished = computed(() => current.value === null)
 

--- a/src/views/Games/components/AddGameForm.vue
+++ b/src/views/Games/components/AddGameForm.vue
@@ -9,7 +9,7 @@ const { wishlist, getWishlistState } = storeToRefs(gameStore)
 const gameName = ref('')
 const addGameInput = useTemplateRef('add-game-input')
 
-const isLoading = computed(() => getWishlistState.value.isLoading.value)
+const isLoading = computed(() => getWishlistState.value.isLoading)
 
 const validator = computed(() => {
 	const result: { ok: boolean; message?: string } = { ok: true }

--- a/src/views/Root/components/AppNavbar.vue
+++ b/src/views/Root/components/AppNavbar.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { RouteName } from '../../../router/routeNames'
-import { useApiWheelStore } from '../../../stores/api/apiWheelStore'
 import UserProfile from './UserProfile.vue'
 import NavbarLink from './NavbarLink.vue'
+import { useFeatureWheelStore } from '../../../stores/feature/featureWheelStore.ts'
 
-const wheelStore = useApiWheelStore()
+const wheelStore = useFeatureWheelStore()
 </script>
 
 <template>

--- a/src/views/Root/components/DisplayNameForm.vue
+++ b/src/views/Root/components/DisplayNameForm.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
-import { LoadingStatus } from '../../../utils/loadingState'
 import { useFeatureUserStore } from '../../../stores/feature/featureUserStore'
 
 const userStore = useFeatureUserStore()
@@ -16,7 +15,7 @@ const displayName = computed(
 )
 
 const isLoading = computed(
-	() => userStore.setDisplayState.state === LoadingStatus.LOADING,
+	() => userStore.setDisplayState.isLoading,
 )
 
 watch(newName, (newName) => {
@@ -76,7 +75,7 @@ const onEscKeyDown = () => {
 		<button
 			class="edit-button"
 			v-if="!showForm"
-			:disabled="userStore.getDisplayNameState.state === LoadingStatus.LOADING"
+			:disabled="userStore.getDisplayNameState.isLoading"
 			@click="onEditButtonClick"
 		>
 			{{ displayName }} <span class="pencil-icon">✏️</span>


### PR DESCRIPTION
## Summary

- Extract `DtoStringToDate`/`DtoStringToDuration` to `dto-types.ts` to break circular dependency between `dto.ts` and model files (caused TS7022)
- Remove spurious `.value` accesses on Pinia auto-unwrapped computed refs (`featureGameStore`, `AddGameForm`)
- Simplify `convertTimerDto` — drop unnecessary undefined guard on non-optional field (`lastActionDate: string`)
- Replace `LoadingStatus` enum comparisons with `.isLoading` accessor in `DisplayNameForm`
- Switch `AppNavbar` from raw API store to feature store

🤖 Generated with [Claude Code](https://claude.com/claude-code)