### PR TITLE
fix: Add npm install step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Install dependencies
+        run: npm install
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Fixes release workflow that failed with `'tauri' is not recognized` because `npm install` wasn't run before the build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)