### PR TITLE
Rename app from fgg-snail to FavoriteGameGauntlet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,6 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'Release ${{ github.ref_name }}'
+          releaseBody: 'Для установки скачайте только файл `_x64-setup.exe`. Остальные не трогайте, они используются для автообновления.'
           releaseDraft: false
           prerelease: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "fgg",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "fgg",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"dependencies": {
 				"@js-temporal/polyfill": "^0.5.1",
 				"@tauri-apps/api": "^2.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "fgg-snail",
+	"name": "fgg",
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "fgg-snail",
+			"name": "fgg",
 			"version": "0.1.0",
 			"dependencies": {
 				"@js-temporal/polyfill": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "fgg",
 	"private": true,
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"type": "module",
 	"engines": {
 		"node": "24.13.1",
@@ -14,7 +14,8 @@
 		"tauri": "tauri",
 		"format": "prettier src/**/*{.vue,.ts} -w",
 		"lint": "eslint ./src",
-		"lint:fix": "eslint ./src --fix"
+		"lint:fix": "eslint ./src --fix",
+		"version": "node scripts/bump-version.mjs"
 	},
 	"dependencies": {
 		"@js-temporal/polyfill": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "fgg-snail",
+	"name": "fgg",
 	"private": true,
 	"version": "0.1.0",
 	"type": "module",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,17 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { execSync } from 'child_process'
+
+const version = process.env.npm_package_version
+
+const tauriConfPath = 'src-tauri/tauri.conf.json'
+const cargoTomlPath = 'src-tauri/Cargo.toml'
+
+const tauriConf = readFileSync(tauriConfPath, 'utf8')
+writeFileSync(tauriConfPath, tauriConf.replace(/"version": "[^"]+"/, `"version": "${version}"`))
+
+const cargoToml = readFileSync(cargoTomlPath, 'utf8')
+writeFileSync(cargoTomlPath, cargoToml.replace(/^version = "[^"]+"/m, `version = "${version}"`))
+
+execSync('cargo update -p fgg', { cwd: 'src-tauri' })
+
+execSync(`git add ${tauriConfPath} ${cargoTomlPath} src-tauri/Cargo.lock`)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "fgg-snail"
+name = "fgg"
 version = "0.1.0"
 dependencies = [
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fgg"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fgg-snail"
+name = "fgg"
 version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]
@@ -11,7 +11,7 @@ edition = "2021"
 # The `_lib` suffix may seem redundant but it is necessary
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
-name = "fgg_snail_lib"
+name = "fgg_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,7 +23,7 @@ pub fn run() {
         .plugin(
             tauri_plugin_stronghold::Builder::new(|password| {
                 use argon2::Argon2;
-                let salt = b"fgg-snail-vault-salt-v1";
+                let salt = b"fgg-vault-salt-v1";
                 let mut key = [0u8; 32];
                 Argon2::default()
                     .hash_password_into(password.as_bytes(), salt, &mut key)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    fgg_snail_lib::run()
+    fgg_lib::run()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "FavoriteGameGauntlet",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"identifier": "com.fgg-challenge.app",
 	"build": {
 		"beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
-	"productName": "FGG",
+	"productName": "FavoriteGameGauntlet",
 	"version": "0.1.0",
-	"identifier": "com.fgg.aboba",
+	"identifier": "com.fgg-challenge.app",
 	"build": {
 		"beforeDevCommand": "npm run dev",
 		"devUrl": "http://localhost:1420",
@@ -12,13 +12,16 @@
 	"app": {
 		"windows": [
 			{
-				"title": "FGG",
+				"title": "Favorite Game Gauntlet",
 				"width": 800,
-				"height": 600
+				"height": 600,
+				"minWidth": 800,
+				"minHeight": 600,
+				"center": true
 			}
 		],
 		"security": {
-			"csp": null
+			"csp": "default-src 'self'; connect-src 'self' https://api.fgg-challenge.com; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https:; font-src 'self' data:"
 		}
 	},
 	"plugins": {
@@ -33,12 +36,10 @@
 		"active": true,
 		"createUpdaterArtifacts": true,
 		"targets": "nsis",
-		"icon": [
-			"icons/32x32.png",
-			"icons/128x128.png",
-			"icons/128x128@2x.png",
-			"icons/icon.icns",
-			"icons/icon.ico"
-		]
+		"windows": {
+			"nsis": {
+				"installMode": "both"
+			}
+		}
 	}
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
-	"productName": "fgg-snail",
+	"productName": "FGG",
 	"version": "0.1.0",
-	"identifier": "com.fgg-snail.aboba",
+	"identifier": "com.fgg.aboba",
 	"build": {
 		"beforeDevCommand": "npm run dev",
 		"devUrl": "http://localhost:1420",
@@ -12,7 +12,7 @@
 	"app": {
 		"windows": [
 			{
-				"title": "fgg-snail",
+				"title": "FGG",
 				"width": 800,
 				"height": 600
 			}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
 	"bundle": {
 		"active": true,
 		"createUpdaterArtifacts": true,
-		"targets": "nsis",
+		"targets": "all",
 		"windows": {
 			"nsis": {
 				"installMode": "both"

--- a/src/services/credentialsStorage.ts
+++ b/src/services/credentialsStorage.ts
@@ -2,8 +2,8 @@ import type { Client} from '@tauri-apps/plugin-stronghold';
 import { Stronghold } from '@tauri-apps/plugin-stronghold'
 import { appLocalDataDir } from '@tauri-apps/api/path'
 
-const VAULT_PASSWORD = 'fgg-snail-credentials-vault-v1'
-const CLIENT_NAME = 'fgg-snail'
+const VAULT_PASSWORD = 'fgg-credentials-vault-v1'
+const CLIENT_NAME = 'fgg'
 const USERNAME_KEY = 'username'
 const PASSWORD_KEY = 'password'
 


### PR DESCRIPTION
## Summary

- Rename application from `fgg-snail` to `FGG` / `FavoriteGameGauntlet`
- Update app identifier to `com.fgg-challenge.app`
- Set minimum window size to 800×600 and center on launch
- Add CSP security policy
- Set NSIS installer mode to `both` (per-machine or current user)
- Add `scripts/bump-version.mjs` to sync version across all files via `npm version`
- Add GitHub release description clarifying which file to download

🤖 Generated with [Claude Code](https://claude.com/claude-code)