### PR TITLE
fix: Fetch displayName and fix NaN in wishlist hint

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "fgg"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "argon2",
  "serde",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
 	"bundle": {
 		"active": true,
 		"createUpdaterArtifacts": true,
-		"targets": "all",
+		"targets": "nsis",
 		"icon": [
 			"icons/32x32.png",
 			"icons/128x128.png",

--- a/src/constants/systemParameters.ts
+++ b/src/constants/systemParameters.ts
@@ -1,4 +1,4 @@
-export const systemParameters = {
+export const systemParameterDefs = {
 	timerDurationInS: { name: 'TimerDurationInS', convert: (v: string): number => Number(v) },
 	shouldLimitFreePoints: { name: 'ShouldLimitFreePoints', convert: (v: string): boolean => v === '1' },
 	freePointsMinimum: { name: 'FreePointsMinimum', convert: (v: string): number => Number(v) },

--- a/src/stores/api/apiSystemParametersStore.ts
+++ b/src/stores/api/apiSystemParametersStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { api } from '../../api-facade/api'
 import type { SystemParameter } from '../../api-facade/models/system-parameters-models'
+import { systemParameterDefs } from '../../constants/systemParameters'
 import { StoreName } from '../../enums/storeName'
 import { LoadingStatus, withLoading } from '../../utils/loadingState'
 
@@ -19,7 +20,7 @@ export const useApiSystemParametersStore = defineStore(
 				await api.systemParameters
 					.getAllSystemParameters()
 					.then((params) => {
-						const missingParams = Object.values(systemParameters)
+						const missingParams = Object.values(systemParameterDefs)
 							.map((p) => p.name)
 							.filter((name) => !params.some((p) => p.name === name))
 

--- a/src/stores/feature/featureSystemParametersStore.ts
+++ b/src/stores/feature/featureSystemParametersStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed } from 'vue'
 import { StoreName } from '../../enums/storeName'
-import { systemParameters } from '../../constants/systemParameters'
+import { systemParameterDefs } from '../../constants/systemParameters'
 import type {
 	SystemParameterName,
 	SystemParameterType,
@@ -15,7 +15,7 @@ export const useFeatureSystemParametersStore = defineStore(
 
 		const getByName = <K extends SystemParameterName>(key: K) =>
 			computed(() => {
-				const { name, convert } = systemParameters[key]
+				const { name, convert } = systemParameterDefs[key]
 				return convert(
 					systemParametersStore.systemParameters?.find((p) => p.name === name)
 						?.value as string,

--- a/src/types/systemParameters.ts
+++ b/src/types/systemParameters.ts
@@ -1,7 +1,7 @@
-import type { systemParameters } from '../constants/systemParameters'
+import type { systemParameterDefs } from '../constants/systemParameters'
 
-export type SystemParameterName = keyof typeof systemParameters
+export type SystemParameterName = keyof typeof systemParameterDefs
 
 export type SystemParameterType<K extends SystemParameterName> = ReturnType<
-	(typeof systemParameters)[K]['convert']
+	(typeof systemParameterDefs)[K]['convert']
 >

--- a/src/views/Login/LoginView.vue
+++ b/src/views/Login/LoginView.vue
@@ -5,11 +5,13 @@ import { type HttpErrorResponse } from '../../api-facade/http'
 import { usePersistentRef } from '../../composables/usePersistentRef'
 import { StoreKey } from '../../services/persistentStorage'
 import { useAuthStore } from '../../stores/authStore'
+import { useFeatureUserStore } from '../../stores/feature/featureUserStore'
 import { RouteName } from '../../router/routeNames'
 import UiButton from '../../components/ui/UiButton.vue'
 
 const router = useRouter()
 const authStore = useAuthStore()
+const userStore = useFeatureUserStore()
 
 const login = ref('')
 const password = ref('')
@@ -89,7 +91,10 @@ watch(
 const tryLogIn = async () =>
 	authStore
 		.logIn({ login: login.value, password: password.value })
-		.then(() => router.push({ name: RouteName.Timer }))
+		.then(() => {
+			userStore.init()
+			router.push({ name: RouteName.Timer })
+		})
 		.catch((e) => {
 			if (e.body?.code === 'WRONG_AUTH_DATA') {
 				isAuthError.value = true

--- a/src/views/SignUp/SignUpView.vue
+++ b/src/views/SignUp/SignUpView.vue
@@ -4,9 +4,11 @@ import { RouterLink, useRouter } from 'vue-router'
 import { type HttpErrorResponse } from '../../api-facade/http'
 import UiButton from '../../components/ui/UiButton.vue'
 import { useAuthStore } from '../../stores/authStore'
+import { useFeatureUserStore } from '../../stores/feature/featureUserStore'
 
 const router = useRouter()
 const authStore = useAuthStore()
+const userStore = useFeatureUserStore()
 
 const login = ref('')
 const password = ref('')
@@ -123,7 +125,10 @@ const onFormSubmit = () => {
 			password: password.value,
 			email: email.value,
 		})
-		.then(() => router.push('/'))
+		.then(() => {
+			userStore.init()
+			router.push('/')
+		})
 		.catch((e: HttpErrorResponse) => {
 			serverError.value = e.body?.message
 		})


### PR DESCRIPTION
## Summary

- Fetch `displayName` after login and signup so it appears correctly on first session without a page reload
- Rename `systemParameters` constant to `systemParameterDefs` to avoid shadowing the Vue ref of the same name, which caused NaN values in the wishlist hint UI