### PR TITLE
Simplify timer stores and fix remaining time on page reload

### DIFF
--- a/src/constants/durations.ts
+++ b/src/constants/durations.ts
@@ -1,0 +1,4 @@
+import { Temporal } from '@js-temporal/polyfill'
+
+export const ZERO = Temporal.Duration.from({ seconds: 0 })
+export const ONE_SECOND = Temporal.Duration.from({ seconds: 1 })

--- a/src/stores/api/apiTimerStore.ts
+++ b/src/stores/api/apiTimerStore.ts
@@ -105,15 +105,10 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 
 		toggleState.status.value = LoadingStatus.LOADING
 
-		const prevLastActionDate = lastActionDate.value
-		const prevState = state.value
-
-		lastActionDate.value = Temporal.Now.instant()
-		state.value = TimerState.Paused
-
 		await api.timers
 			.postPause()
 			.then((timer) => {
+				state.value = timer.state
 				durationLeft.value = timer.remainingTime
 				durationTotal.value = timer.duration
 				lastActionDate.value = timer.lastActionDate
@@ -129,9 +124,6 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 					toggleState.status.value = LoadingStatus.LOADED
 					return
 				}
-
-				state.value = prevState
-				lastActionDate.value = prevLastActionDate
 
 				toggleState.status.value = LoadingStatus.ERROR
 				throw error
@@ -151,6 +143,7 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 
 	const markFinished = () => {
 		state.value = TimerState.Finished
+		durationLeft.value = Temporal.Duration.from({ hours: 0 })
 		getCurrent()
 	}
 

--- a/src/stores/api/apiTimerStore.ts
+++ b/src/stores/api/apiTimerStore.ts
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 import { api } from '../../api-facade/api'
 import type { HttpErrorResponse } from '../../api-facade/http'
 import { TimerState } from '../../api-facade/models/timers-models'
+import { ZERO } from '../../constants/durations'
 import { StoreName } from '../../enums/storeName'
 import {
 	LoadingStatus,
@@ -22,7 +23,7 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 	const durationTotal = ref(Temporal.Duration.from(DEFAULT_DURATION))
 
 	const lastActionDate = ref<Temporal.Instant | null>(null)
-	const durationLeft = ref(Temporal.Duration.from({ hours: 0 }))
+	const durationLeft = ref(ZERO)
 
 	const toggleState = makeLoadingState()
 
@@ -53,7 +54,7 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 			})
 			.catch((error: HttpErrorResponse) => {
 				if (error.body?.code === 'AVAILABLE_ROLLS_EXIST') {
-					durationLeft.value = Temporal.Duration.from({ hours: 0 })
+					durationLeft.value = ZERO
 					state.value = null
 					lastActionDate.value = null
 
@@ -139,7 +140,7 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 
 	const markFinished = () => {
 		state.value = TimerState.Finished
-		durationLeft.value = Temporal.Duration.from({ hours: 0 })
+		durationLeft.value = ZERO
 		getCurrent()
 	}
 

--- a/src/stores/api/apiTimerStore.ts
+++ b/src/stores/api/apiTimerStore.ts
@@ -22,7 +22,6 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 	const durationTotal = ref(Temporal.Duration.from(DEFAULT_DURATION))
 
 	const lastActionDate = ref<Temporal.Instant | null>(null)
-	const syncedAt = ref<Temporal.Instant | null>(null)
 	const durationLeft = ref(Temporal.Duration.from({ hours: 0 }))
 
 	const toggleState = makeLoadingState()
@@ -49,7 +48,6 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 				durationLeft.value = timer.remainingTime
 				state.value = timer.state
 				lastActionDate.value = timer.lastActionDate
-				syncedAt.value = Temporal.Now.instant()
 
 				status.value = LoadingStatus.LOADED
 			})
@@ -81,7 +79,6 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 				durationLeft.value = timer.remainingTime
 				durationTotal.value = timer.duration
 				lastActionDate.value = timer.lastActionDate
-				syncedAt.value = Temporal.Now.instant()
 
 				toggleState.status.value = LoadingStatus.LOADED
 			})
@@ -112,7 +109,6 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 				durationLeft.value = timer.remainingTime
 				durationTotal.value = timer.duration
 				lastActionDate.value = timer.lastActionDate
-				syncedAt.value = Temporal.Now.instant()
 
 				toggleState.status.value = LoadingStatus.LOADED
 			})
@@ -157,7 +153,6 @@ export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 		durationLeft,
 
 		lastActionDate,
-		syncedAt,
 
 		canStart,
 		canPause,

--- a/src/stores/feature/featureTimerStore.ts
+++ b/src/stores/feature/featureTimerStore.ts
@@ -2,14 +2,12 @@ import { Temporal } from '@js-temporal/polyfill'
 import { defineStore, storeToRefs } from 'pinia'
 import { computed, ref, watch } from 'vue'
 import { TimerState } from '../../api-facade/models/timers-models'
+import { ZERO, ONE_SECOND } from '../../constants/durations'
 import { StoreName } from '../../enums/storeName'
 import { useApiTimerStore } from '../api/apiTimerStore'
 import { useAuthStore } from '../authStore'
 import { useFeatureGameStore } from './featureGameStore'
 import { useFeatureWheelStore } from './featureWheelStore'
-
-const ZERO = Temporal.Duration.from({ seconds: 0 })
-const ONE_SECOND = Temporal.Duration.from({ seconds: 1 })
 
 export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 	const timerStore = useApiTimerStore()

--- a/src/stores/feature/featureTimerStore.ts
+++ b/src/stores/feature/featureTimerStore.ts
@@ -17,7 +17,7 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 	const gameStore = useFeatureGameStore()
 	const wheelStore = useFeatureWheelStore()
 
-	const { state, durationLeft, durationTotal, syncedAt } =
+	const { state, durationLeft, durationTotal, lastActionDate } =
 		storeToRefs(timerStore)
 	const { isLoggedIn } = storeToRefs(authStore)
 
@@ -37,12 +37,12 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 	}
 
 	const calcRemaining = (): Temporal.Duration => {
-		if (!syncedAt.value || state.value !== TimerState.Running)
+		if (!lastActionDate.value || state.value !== TimerState.Running)
 			return durationLeft.value
 
-		const sinceSync = Temporal.Now.instant().since(syncedAt.value)
+		const sinceLastAction = Temporal.Now.instant().since(lastActionDate.value)
 
-		const left = durationLeft.value.subtract(sinceSync)
+		const left = durationLeft.value.subtract(sinceLastAction)
 		if (left.sign <= 0) return ZERO
 
 		const floored = left.round({
@@ -99,7 +99,6 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 	})
 
 	const init = () => {
-		// Get current timer on login
 		watch(
 			isLoggedIn,
 			(loggedIn) => {

--- a/src/stores/feature/featureTimerStore.ts
+++ b/src/stores/feature/featureTimerStore.ts
@@ -1,5 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill'
-import { defineStore } from 'pinia'
+import { defineStore, storeToRefs } from 'pinia'
 import { computed, ref, watch } from 'vue'
 import { TimerState } from '../../api-facade/models/timers-models'
 import { StoreName } from '../../enums/storeName'
@@ -8,28 +8,42 @@ import { useAuthStore } from '../authStore'
 import { useFeatureGameStore } from './featureGameStore'
 import { useFeatureWheelStore } from './featureWheelStore'
 
+const ZERO = Temporal.Duration.from({ seconds: 0 })
+const ONE_SECOND = Temporal.Duration.from({ seconds: 1 })
+
 export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 	const timerStore = useApiTimerStore()
 	const authStore = useAuthStore()
 	const gameStore = useFeatureGameStore()
 	const wheelStore = useFeatureWheelStore()
 
+	const { state, durationLeft, durationTotal, syncedAt } =
+		storeToRefs(timerStore)
+	const { isLoggedIn } = storeToRefs(authStore)
+
 	const loading = computed(
 		() =>
 			timerStore.toggleState.isLoading || timerStore.getCurrentState.isLoading,
 	)
 
-	const remaining = ref(Temporal.Duration.from({ seconds: 0 }))
+	const remaining = ref(ZERO)
 	let interval: ReturnType<typeof setInterval> | null = null
 
+	const stopInterval = () => {
+		if (interval) {
+			clearInterval(interval)
+			interval = null
+		}
+	}
+
 	const calcRemaining = (): Temporal.Duration => {
-		if (!timerStore.syncedAt || timerStore.state !== TimerState.Running)
-			return timerStore.durationLeft
+		if (!syncedAt.value || state.value !== TimerState.Running)
+			return durationLeft.value
 
-		const sinceSync = Temporal.Now.instant().since(timerStore.syncedAt)
+		const sinceSync = Temporal.Now.instant().since(syncedAt.value)
 
-		const left = timerStore.durationLeft.subtract(sinceSync)
-		if (left.sign <= 0) return Temporal.Duration.from({ seconds: 0 })
+		const left = durationLeft.value.subtract(sinceSync)
+		if (left.sign <= 0) return ZERO
 
 		const floored = left.round({
 			largestUnit: 'hour',
@@ -37,31 +51,21 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 			roundingMode: 'floor',
 		})
 
-		return floored.total({ unit: 'seconds' }) > 0
-			? floored
-			: Temporal.Duration.from({ seconds: 1 })
+		return floored.sign > 0 ? floored : ONE_SECOND
 	}
 
 	watch(
-		() => timerStore.state,
-		(newState, oldState) => {
-			if (interval) {
-				clearInterval(interval)
-				interval = null
-			}
-
-			if (oldState !== TimerState.Running) {
-				remaining.value = calcRemaining()
-			}
+		[state, durationLeft],
+		([newState]) => {
+			stopInterval()
+			remaining.value = calcRemaining()
 
 			if (newState === TimerState.Running) {
 				interval = setInterval(() => {
 					remaining.value = calcRemaining()
 
-					if (remaining.value.total({ unit: 'seconds' }) <= 0) {
-						clearInterval(interval!)
-						interval = null
-						remaining.value = Temporal.Duration.from({ seconds: 0 })
+					if (remaining.value.sign <= 0) {
+						stopInterval()
 						timerStore.markFinished()
 					}
 				}, 1000)
@@ -70,21 +74,14 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 		{ immediate: true },
 	)
 
-	watch(
-		() => timerStore.durationLeft,
-		() => {
-			remaining.value = calcRemaining()
-		},
-	)
-
-	const remainingAtLastGameUpdate = ref(Temporal.Duration.from({ seconds: 0 }))
+	const remainingAtLastGameUpdate = ref(ZERO)
 
 	watch(
 		[() => gameStore.current?.timeSpent, remaining],
 		([newTimeSpent], [prevTimeSpent]) => {
 			if (
 				newTimeSpent !== prevTimeSpent ||
-				remainingAtLastGameUpdate.value.total({ unit: 'seconds' }) === 0
+				remainingAtLastGameUpdate.value.sign === 0
 			) {
 				remainingAtLastGameUpdate.value = remaining.value
 			}
@@ -93,8 +90,7 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 	)
 
 	const elapsed = computed(() => {
-		const timeSpent =
-			gameStore.current?.timeSpent ?? Temporal.Duration.from({ seconds: 0 })
+		const timeSpent = gameStore.current?.timeSpent ?? ZERO
 		const sinceLastUpdate = remainingAtLastGameUpdate.value.subtract(
 			remaining.value,
 		)
@@ -105,9 +101,9 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 	const init = () => {
 		// Get current timer on login
 		watch(
-			() => authStore.isLoggedIn,
-			(isLoggedIn) => {
-				if (isLoggedIn) {
+			isLoggedIn,
+			(loggedIn) => {
+				if (loggedIn) {
 					timerStore.getCurrent()
 				} else {
 					timerStore.reset()
@@ -118,9 +114,9 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 	}
 
 	return {
-		state: computed(() => timerStore.state),
+		state,
 
-		durationTotal: computed(() => timerStore.durationTotal),
+		durationTotal,
 		remaining,
 		elapsed,
 


### PR DESCRIPTION
## Summary

- Remove the optimistic state update from `pause()` so timer state only changes together with fresh server data, dropping the rollback logic it required
- Merge the `state` and `durationLeft` watchers in `featureTimerStore` into one and drop the `oldState` guard that only existed because of the optimistic update
- Zero `durationLeft` in `markFinished()` so the remaining time never jumps back to a stale value while `getCurrent()` is in flight
- Use `storeToRefs` instead of getter lambdas in watch sources and computed re-exports in the store return
- Extract `ZERO`/`ONE_SECOND` duration constants into `src/constants/durations.ts` and reuse them in both timer stores
- Fix: compute remaining time from `lastActionDate` instead of the response arrival time. `GET /timers/current` returns `remainingTime` as of the last action, so a running timer used to reset to its last-action value on every page reload; the unused `syncedAt` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)