### PR TITLE
Block timer access when no timer is available

### DIFF
--- a/src/constants/systemParameters.ts
+++ b/src/constants/systemParameters.ts
@@ -1,15 +1,50 @@
 export const systemParameterDefs = {
-	timerDurationInS: { name: 'TimerDurationInS', convert: (v: string): number => Number(v) },
-	shouldLimitFreePoints: { name: 'ShouldLimitFreePoints', convert: (v: string): boolean => v === '1' },
-	freePointsMinimum: { name: 'FreePointsMinimum', convert: (v: string): number => Number(v) },
-	minimumNumberOfWishlistGames: { name: 'MinimumNumberOfWishlistGames', convert: (v: string): number => Number(v) },
-	availableRollChangeByRoll: { name: 'AvailableRollChangeByRoll', convert: (v: string): number => Number(v) },
-	maximumAvailableRollCountForTimer: { name: 'MaximumAvailableRollCountForTimer', convert: (v: string): number => Number(v) },
-	minimumAvailableRollCountForRoll: { name: 'MinimumAvailableRollCountForRoll', convert: (v: string): number => Number(v) },
-	seizePenaltyPoints: { name: 'SeizePenaltyPoints', convert: (v: string): number => Number(v) },
-	availableRollChangeByTimer: { name: 'AvailableRollChangeByTimer', convert: (v: string): number => Number(v) },
-	territoryHourChangeByTimer: { name: 'TerritoryHourChangeByTimer', convert: (v: string): number => Number(v) },
-	experiencePointChangeByTimer: { name: 'ExperiencePointChangeByTimer', convert: (v: string): number => Number(v) },
-	experiencePointChangeByLevelUp: { name: 'ExperiencePointChangeByLevelUp', convert: (v: string): number => Number(v) },
-	territoryHourChangeBySeizeSlice: { name: 'TerritoryHourChangeBySeizeSlice', convert: (v: string): number[] => JSON.parse(v) },
+	shouldLimitFreePoints: {
+		name: 'ShouldLimitFreePoints',
+		convert: (v: string): boolean => v === '1',
+	},
+	freePointsMinimum: {
+		name: 'FreePointsMinimum',
+		convert: (v: string): number => Number(v),
+	},
+	minimumNumberOfWishlistGames: {
+		name: 'MinimumNumberOfWishlistGames',
+		convert: (v: string): number => Number(v),
+	},
+	availableRollChangeByRoll: {
+		name: 'AvailableRollChangeByRoll',
+		convert: (v: string): number => Number(v),
+	},
+	maximumAvailableRollCountForTimer: {
+		name: 'MaximumAvailableRollCountForTimer',
+		convert: (v: string): number => Number(v),
+	},
+	minimumAvailableRollCountForRoll: {
+		name: 'MinimumAvailableRollCountForRoll',
+		convert: (v: string): number => Number(v),
+	},
+	seizePenaltyPoints: {
+		name: 'SeizePenaltyPoints',
+		convert: (v: string): number => Number(v),
+	},
+	availableRollChangeByTimer: {
+		name: 'AvailableRollChangeByTimer',
+		convert: (v: string): number => Number(v),
+	},
+	territoryHourChangeByTimer: {
+		name: 'TerritoryHourChangeByTimer',
+		convert: (v: string): number => Number(v),
+	},
+	experiencePointChangeByTimer: {
+		name: 'ExperiencePointChangeByTimer',
+		convert: (v: string): number => Number(v),
+	},
+	experiencePointChangeByLevelUp: {
+		name: 'ExperiencePointChangeByLevelUp',
+		convert: (v: string): number => Number(v),
+	},
+	territoryHourChangeBySeizeSlice: {
+		name: 'TerritoryHourChangeBySeizeSlice',
+		convert: (v: string): number[] => JSON.parse(v),
+	},
 }

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -2,6 +2,7 @@ import { createMemoryHistory, createRouter } from 'vue-router'
 import { authGuard } from './authGuard'
 import { initialPathGuard } from './initialPathGuard'
 import { routes } from './routes'
+import { timerAccessGuard } from './timerAccessGuard'
 
 export const router = createRouter({
 	history: createMemoryHistory(),
@@ -10,3 +11,4 @@ export const router = createRouter({
 
 router.beforeEach(initialPathGuard)
 router.beforeEach(authGuard)
+router.beforeEach(timerAccessGuard)

--- a/src/router/timerAccessGuard.ts
+++ b/src/router/timerAccessGuard.ts
@@ -1,0 +1,17 @@
+import { type NavigationGuard } from 'vue-router'
+import { useApiTimerStore } from '../stores/api/apiTimerStore'
+import { useFeatureTimerStore } from '../stores/feature/featureTimerStore'
+import { LoadingStatus } from '../utils/loadingState'
+import { RouteName } from './routeNames'
+
+export const timerAccessGuard: NavigationGuard = async (to) => {
+	if (to.name !== RouteName.Timer) return true
+
+	const timerStore = useApiTimerStore()
+	await timerStore.getCurrentState.on([
+		LoadingStatus.LOADED,
+		LoadingStatus.ERROR,
+	])
+
+	return !useFeatureTimerStore().timerUnavailable || { name: RouteName.Games }
+}

--- a/src/stores/api/apiTimerStore.ts
+++ b/src/stores/api/apiTimerStore.ts
@@ -12,15 +12,9 @@ import {
 	withLoading,
 } from '../../utils/loadingState'
 
-const DEFAULT_DURATION = Temporal.Duration.from({
-	hours: 2,
-	minutes: 0,
-	seconds: 0,
-})
-
 export const useApiTimerStore = defineStore(StoreName.ApiTimer, () => {
 	const state = ref<TimerState | null>(null)
-	const durationTotal = ref(Temporal.Duration.from(DEFAULT_DURATION))
+	const durationTotal = ref(ZERO)
 
 	const lastActionDate = ref<Temporal.Instant | null>(null)
 	const durationLeft = ref(ZERO)

--- a/src/stores/feature/featureSystemParametersStore.ts
+++ b/src/stores/feature/featureSystemParametersStore.ts
@@ -22,7 +22,6 @@ export const useFeatureSystemParametersStore = defineStore(
 				) as SystemParameterType<K>
 			})
 
-		const timerDurationInS = getByName('timerDurationInS')
 		const shouldLimitFreePoints = getByName('shouldLimitFreePoints')
 		const freePointsMinimum = getByName('freePointsMinimum')
 		const minimumNumberOfWishlistGames = getByName(
@@ -53,7 +52,6 @@ export const useFeatureSystemParametersStore = defineStore(
 		}
 
 		return {
-			timerDurationInS,
 			shouldLimitFreePoints,
 			freePointsMinimum,
 			minimumNumberOfWishlistGames,

--- a/src/stores/feature/featureTimerStore.ts
+++ b/src/stores/feature/featureTimerStore.ts
@@ -24,6 +24,13 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 			timerStore.toggleState.isLoading || timerStore.getCurrentState.isLoading,
 	)
 
+	const timerUnavailable = computed(
+		() =>
+			(timerStore.getCurrentState.isLoaded ||
+				timerStore.getCurrentState.isError) &&
+			state.value === null,
+	)
+
 	const remaining = ref(ZERO)
 	let interval: ReturnType<typeof setInterval> | null = null
 
@@ -108,6 +115,19 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 			},
 			{ immediate: true },
 		)
+
+		// A new game means a new timer to fetch; finishing/cancelling a
+		// game always leaves no timer, so reset locally without a request
+		watch(
+			() => gameStore.current,
+			(current) => {
+				if (current) {
+					timerStore.getCurrent()
+				} else {
+					timerStore.reset()
+				}
+			},
+		)
 	}
 
 	return {
@@ -118,6 +138,7 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 		elapsed,
 
 		loading,
+		timerUnavailable,
 
 		toggle: timerStore.toggle,
 		canToggle: computed(() => timerStore.canToggle && !wheelStore.pendingRoll),

--- a/src/views/Root/components/AppNavbar.vue
+++ b/src/views/Root/components/AppNavbar.vue
@@ -3,8 +3,10 @@ import { RouteName } from '../../../router/routeNames'
 import UserProfile from './UserProfile.vue'
 import NavbarLink from './NavbarLink.vue'
 import { useFeatureWheelStore } from '../../../stores/feature/featureWheelStore.ts'
+import { useFeatureTimerStore } from '../../../stores/feature/featureTimerStore.ts'
 
 const wheelStore = useFeatureWheelStore()
+const timerStore = useFeatureTimerStore()
 </script>
 
 <template>
@@ -12,7 +14,9 @@ const wheelStore = useFeatureWheelStore()
 		<UserProfile />
 
 		<div class="navbar__links">
-			<NavbarLink :to="RouteName.Timer"> Таймер </NavbarLink>
+			<NavbarLink :to="RouteName.Timer" :disabled="timerStore.timerUnavailable">
+				Таймер
+			</NavbarLink>
 
 			<NavbarLink :to="RouteName.Effects">
 				Роллы {{ wheelStore.pendingRoll ? '🔵' : '' }}

--- a/src/views/Root/components/NavbarLink.vue
+++ b/src/views/Root/components/NavbarLink.vue
@@ -6,7 +6,7 @@ import { storeToRefs } from 'pinia'
 import { useSettingsStore } from '../../../stores/settingsStore'
 import { useResizeObserver } from '../../../composables/useResizeObserver'
 
-defineProps<{ to: RouteName }>()
+defineProps<{ to: RouteName; disabled?: boolean }>()
 
 const seed = Math.floor(Math.random() * Math.pow(2, 31)) + 1
 
@@ -63,6 +63,7 @@ watch(roughnessModifier, drawShapes)
 <template>
 	<RouterLink
 		class="navbar-link"
+		:class="{ 'navbar-link--disabled': disabled }"
 		activeClass="navbar-link--active"
 		:to="{ name: to }"
 	>
@@ -93,6 +94,13 @@ watch(roughnessModifier, drawShapes)
 
 .navbar-link--active {
 	color: black;
+}
+
+.navbar-link--disabled {
+	pointer-events: none;
+	user-select: none;
+	cursor: default;
+	opacity: 0.4;
 }
 
 .navbar-link__svg {


### PR DESCRIPTION
## Summary
- Redirect away from the timer route (to Games) and disable the "Таймер" navbar link once the timer fetch has settled (loaded or errored) and there's still no timer, instead of showing a timer that doesn't exist.
- Re-fetch the timer whenever a new game starts, so its state stays in sync.
- Reset the timer locally (no request) when the current game is finished or cancelled, since that always means there's no timer.