### PR TITLE
Add startDate alongside finishDate for games

### DIFF
--- a/src/api-facade/dto.ts
+++ b/src/api-facade/dto.ts
@@ -14,6 +14,7 @@ import type {
 
 export const convertGameDto = (game: CurrentGameDto): CurrentGame => ({
 	...game,
+	startDate: Temporal.Instant.from(game.startDate),
 	finishDate:
 		game.finishDate !== undefined
 			? Temporal.Instant.from(game.finishDate)

--- a/src/api-facade/models/games-models.ts
+++ b/src/api-facade/models/games-models.ts
@@ -21,10 +21,11 @@ export type CurrentGameDto = {
 	state: GameState
 	/** format: Duration */
 	timeSpent: string
+	startDate: string
 	finishDate?: string
 }
 
 export type CurrentGame = DtoStringToDuration<
-	DtoStringToDate<CurrentGameDto, 'finishDate'>,
+	DtoStringToDate<CurrentGameDto, 'startDate' | 'finishDate'>,
 	'timeSpent'
 >

--- a/src/views/Games/GamesView.vue
+++ b/src/views/Games/GamesView.vue
@@ -105,6 +105,9 @@ onMounted(() => {
 				<div class="current-game-elapsed">
 					затрачено <UiTimestamp :time="current.timeSpent" />
 				</div>
+				<div class="current-game-started">
+					начато {{ formatInstant(current.startDate) }}
+				</div>
 				<div class="current-game-actions">
 					<UiButton class="status-button" @click="gameStore.cancel()">
 						отменить
@@ -164,6 +167,9 @@ onMounted(() => {
 						<span class="history-card__meta"
 							><UiTimestamp :time="game.timeSpent"
 						/></span>
+						<span class="history-card__meta">{{
+							formatInstant(game.startDate)
+						}}</span>
 						<span v-if="game.finishDate" class="history-card__meta">{{
 							formatInstant(game.finishDate)
 						}}</span>

--- a/src/views/Users/OtherUserProfileView.vue
+++ b/src/views/Users/OtherUserProfileView.vue
@@ -81,6 +81,7 @@ watch(login, loadAll)
 						<span class="game-status-badge">{{
 							gameStateLabel[currentGame.state]
 						}}</span>
+						<span class="item-meta">{{ formatInstant(currentGame.startDate) }}</span>
 					</span>
 				</div>
 			</div>
@@ -166,6 +167,16 @@ watch(login, loadAll)
 								<span class="item-meta"
 									><UiTimestamp :time="game.timeSpent"
 								/></span>
+							</div>
+							<div class="info-card__row">
+								<span class="item-meta">Начало</span>
+								<span class="item-meta">{{ formatInstant(game.startDate) }}</span>
+							</div>
+							<div class="info-card__row">
+								<span class="item-meta">Конец</span>
+								<span class="item-meta">{{
+									game.finishDate ? formatInstant(game.finishDate) : '—'
+								}}</span>
 							</div>
 						</li>
 					</ul>


### PR DESCRIPTION
## Summary
- Added required `startDate` field to `CurrentGameDto`/`CurrentGame`, converted the same way as `finishDate`
- Show the start date in the current-game card and games history on the Games view
- Show the start date (and finish date) in the other-user profile's current game and games history