### PR TITLE
Add foreign player selection to territory hours change

### DIFF
--- a/src/api-facade/models/points-models.ts
+++ b/src/api-facade/models/points-models.ts
@@ -20,6 +20,11 @@ export type PointChangeWithLogin = {
 	pointChange: PointChange
 }
 
+export type TerritoryHourChange = PointChange & {
+	isSomeones: boolean
+	login?: string
+}
+
 export enum TerritoryChangeSource {
 	ObtainingTerritory = 'territory-obtaining',
 	LosingTerritory = 'territory-loss',

--- a/src/api-facade/models/points-models.ts
+++ b/src/api-facade/models/points-models.ts
@@ -10,7 +10,7 @@ export type PointChange = {
 	desiredChangeValue: number
 }
 
-export type PointChangeResult = PointChange & {
+export type PointChangeResult = {
 	actualChangeValue: number
 	finalValue: number
 }
@@ -25,6 +25,11 @@ export type TerritoryHourChange = PointChange & {
 	login?: string
 }
 
+export type TerritoryHourChangeResult = {
+	territoryHours?: PointChangeResult
+	territoryPoints?: PointChangeResult
+}
+
 export enum TerritoryChangeSource {
 	ObtainingTerritory = 'territory-obtaining',
 	LosingTerritory = 'territory-loss',
@@ -37,11 +42,11 @@ export const territoryChangeSourceLabel: Record<TerritoryChangeSource, string> =
 	[TerritoryChangeSource.Other]: 'Другое',
 }
 
-export type TerritoryPointChangeResult = PointChangeResult & {
-	changeSource: TerritoryChangeSource
-}
+export type TerritoryPointChangeResult = PointChangeResult
 
-export type TerritoryPointChangeHistoryDto = TerritoryPointChangeResult & {
+export type TerritoryPointChangeHistoryDto = PointChangeResult & {
+	changeSource: TerritoryChangeSource
+	desiredChangeValue: number
 	changeDate: string
 	sourceLogin?: string
 }
@@ -91,11 +96,11 @@ export type FreePointChange = PointChange & {
 	wheelEffectName?: string
 }
 
-export type FreePointChangeResult = PointChangeResult & {
-	changeSource: FreePointChangeSource
-}
+export type FreePointChangeResult = PointChangeResult
 
-export type FreePointChangeHistoryDto = FreePointChangeResult & {
+export type FreePointChangeHistoryDto = PointChangeResult & {
+	changeSource: FreePointChangeSource
+	desiredChangeValue: number
 	changeDate: string
 	sourceLogin?: string
 	wheelEffectName?: string

--- a/src/api-facade/requests/points-requests.ts
+++ b/src/api-facade/requests/points-requests.ts
@@ -6,6 +6,7 @@ import type {
 	PointChangeResult,
 	PointInfo,
 	TerritoryHourChange,
+	TerritoryHourChangeResult,
 	TerritoryPointChangeHistoryDto,
 	TerritoryPointChangeResult,
 } from '../models/points-models'
@@ -97,7 +98,7 @@ export type PostTerritoryHours = {
 	request: {
 		body: TerritoryHourChange
 	}
-	response: PointChangeResult
+	response: TerritoryHourChangeResult
 }
 
 export type GetTerritoryHours = {

--- a/src/api-facade/requests/points-requests.ts
+++ b/src/api-facade/requests/points-requests.ts
@@ -5,6 +5,7 @@ import type {
 	PointChange,
 	PointChangeResult,
 	PointInfo,
+	TerritoryHourChange,
 	TerritoryPointChangeHistoryDto,
 	TerritoryPointChangeResult,
 } from '../models/points-models'
@@ -94,7 +95,7 @@ export type GetExperiencePoints = {
 
 export type PostTerritoryHours = {
 	request: {
-		body: PointChange
+		body: TerritoryHourChange
 	}
 	response: PointChangeResult
 }

--- a/src/stores/api/apiPointsStore.ts
+++ b/src/stores/api/apiPointsStore.ts
@@ -11,8 +11,11 @@ import type {
 } from '../../api-facade/models/points-models'
 import { StoreName } from '../../enums/storeName'
 import { LoadingStatus, withLoading } from '../../utils/loadingState'
+import { useAuthStore } from '../authStore'
 
 export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
+	const authStore = useAuthStore()
+
 	const pointsInfo = ref<Record<string, PointInfo>>({})
 	const freePointsHistory = ref<Record<string, FreePointChangeHistory[]>>({})
 	const territoryPointsHistory = ref<Record<string, TerritoryPointChangeHistory[]>>({})
@@ -199,7 +202,29 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 			return api.points
 				.postTerritoryHours({ body: change })
 				.then((result) => {
-					territoryHours.value = result.finalValue
+					if (result.territoryHours) {
+						territoryHours.value = result.territoryHours.finalValue
+					}
+
+					if (result.territoryPoints) {
+						const affectedLogins = [authStore.login, change.login].filter(
+							(login): login is string => !!login,
+						)
+
+						for (const affectedLogin of affectedLogins) {
+							api.points
+								.getTerritoryPoints({ path: { login: affectedLogin } })
+								.then((value) => {
+									territoryPoints.value[affectedLogin] = value
+								})
+							api.points
+								.getTerritoryPointsHistory({ path: { login: affectedLogin } })
+								.then((history) => {
+									territoryPointsHistory.value[affectedLogin] = history
+								})
+						}
+					}
+
 					status.value = LoadingStatus.LOADED
 
 					return result

--- a/src/stores/api/apiPointsStore.ts
+++ b/src/stores/api/apiPointsStore.ts
@@ -6,6 +6,7 @@ import type {
 	FreePointChangeHistory,
 	PointChange,
 	PointInfo,
+	TerritoryHourChange,
 	TerritoryPointChangeHistory,
 } from '../../api-facade/models/points-models'
 import { StoreName } from '../../enums/storeName'
@@ -190,7 +191,7 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 	)
 
 	const [postTerritoryHours, postTerritoryHoursState] = withLoading(
-		async (status, change: PointChange) => {
+		async (status, change: TerritoryHourChange) => {
 			if (status.value === LoadingStatus.LOADING) return
 
 			status.value = LoadingStatus.LOADING

--- a/src/stores/feature/featureUserStore.ts
+++ b/src/stores/feature/featureUserStore.ts
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import type {
 	FreePointChange,
 	PointChange,
+	TerritoryHourChange,
 } from '../../api-facade/models/points-models'
 import type { Login } from '../../api-facade/models/users-models'
 import { StoreName } from '../../enums/storeName'
@@ -25,6 +26,9 @@ export const useFeatureUserStore = defineStore(StoreName.FeatureUser, () => {
 	}))
 
 	const users = computed(() => apiStore.users)
+	const otherUsers = computed(
+		() => apiStore.users?.filter((u) => u.login !== authStore.login) ?? [],
+	)
 
 	const init = async () => {
 		await apiStore.getDisplayName()
@@ -48,7 +52,7 @@ export const useFeatureUserStore = defineStore(StoreName.FeatureUser, () => {
 	const userTerritoryHours = computed(() => pointsStore.territoryHours)
 	const changeExperiencePoints = (change: PointChange) =>
 		pointsStore.postExperiencePoints(change)
-	const changeTerritoryHours = (change: PointChange) =>
+	const changeTerritoryHours = (change: TerritoryHourChange) =>
 		pointsStore.postTerritoryHours(change)
 	const changeFreePoints = (login: string, change: FreePointChange) =>
 		pointsStore.postFreePoints(login, change)
@@ -56,6 +60,7 @@ export const useFeatureUserStore = defineStore(StoreName.FeatureUser, () => {
 	return {
 		currentUser,
 		users,
+		otherUsers,
 
 		setDisplayState: apiStore.setDisplayNameState,
 		getDisplayNameState: apiStore.getDisplayNameState,

--- a/src/views/Profile/ProfileView.vue
+++ b/src/views/Profile/ProfileView.vue
@@ -26,6 +26,9 @@ const displayName = computed(() => userStore.currentUser.displayName)
 const pointsInfo = computed(() =>
 	login.value ? (userStore.userPoints[login.value] ?? null) : null,
 )
+const territoryPoints = computed(() =>
+	login.value ? (userStore.userTerritoryPoints[login.value] ?? null) : null,
+)
 const experiencePoints = computed(() => userStore.userExperiencePoints)
 const territoryHours = computed(() => userStore.userTerritoryHours)
 
@@ -39,18 +42,21 @@ const territoryHistory = computed(() =>
 const isLoading = computed(
 	() =>
 		userStore.getUserPointsState.isLoading ||
+		userStore.getUserTerritoryPointsState.isLoading ||
 		userStore.getUserExperiencePointsState.isLoading ||
 		userStore.getUserTerritoryHoursState.isLoading,
 )
 const isError = computed(
 	() =>
 		userStore.getUserPointsState.isError ||
+		userStore.getUserTerritoryPointsState.isError ||
 		userStore.getUserExperiencePointsState.isError ||
 		userStore.getUserTerritoryHoursState.isError,
 )
 const isLoaded = computed(
 	() =>
 		userStore.getUserPointsState.isLoaded &&
+		userStore.getUserTerritoryPointsState.isLoaded &&
 		userStore.getUserExperiencePointsState.isLoaded &&
 		userStore.getUserTerritoryHoursState.isLoaded,
 )
@@ -64,6 +70,7 @@ const loadAll = () => {
 	if (!login.value) return
 
 	userStore.getUserPoints(login.value)
+	userStore.getUserTerritoryPoints(login.value)
 	userStore.getUserExperiencePoints()
 	userStore.getUserTerritoryHours()
 	userStore.getUserFreePointsHistory(login.value)
@@ -106,7 +113,7 @@ watch(login, loadAll)
 						<div class="metric-card__header">
 							<span class="metric-label">Очки территорий</span>
 						</div>
-						<div class="metric-value">{{ pointsInfo?.territoryPoints }}</div>
+						<div class="metric-value">{{ territoryPoints }}</div>
 					</div>
 
 					<div class="metric-card">

--- a/src/views/Profile/components/TerritoryHoursForm.vue
+++ b/src/views/Profile/components/TerritoryHoursForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { type HttpErrorResponse } from '../../../api-facade/http'
 import {
 	TerritoryHourChangeSource,
 	territoryHourChangeSourceLabel,
@@ -16,6 +17,7 @@ const seizeSliceIndex = ref<number | null>(null)
 const applyPenalty = ref(false)
 const targetLogin = ref<string | null>(null)
 const amount = ref<number | null>(null)
+const errorMessage = ref<string>()
 
 const isSeize = computed(
 	() => reason.value === TerritoryHourChangeSource.Seize,
@@ -53,6 +55,10 @@ watch(applyPenalty, (value) => {
 	}
 })
 
+watch(targetLogin, () => {
+	errorMessage.value = undefined
+})
+
 const closeModal = () => {
 	showModal.value = false
 	reason.value = TerritoryHourChangeSource.Seize
@@ -60,6 +66,7 @@ const closeModal = () => {
 	applyPenalty.value = false
 	targetLogin.value = null
 	amount.value = null
+	errorMessage.value = undefined
 }
 
 const onEditButtonClick = () => {
@@ -73,11 +80,11 @@ const onEditButtonClick = () => {
 const onFormSubmit = () => {
 	if (isLoading.value) return
 
+	errorMessage.value = undefined
+
 	const desiredChangeValue = isSeize.value
 		? seizeSliceIndex.value !== null
-			? (systemParametersStore.territoryHourChangeBySeizeSlice[
-					seizeSliceIndex.value
-				] ?? null)
+			? (seizeSliceDisplayValues.value[seizeSliceIndex.value] ?? null)
 			: null
 		: amount.value
 
@@ -95,6 +102,14 @@ const onFormSubmit = () => {
 		})
 		.then(() => {
 			closeModal()
+		})
+		.catch((error: HttpErrorResponse) => {
+			if (error.body?.code === 'NOT_ENOUGH_CURRENT_POINTS') {
+				errorMessage.value =
+					'У выбранного игрока недостаточно очков территорий. Выберите другого игрока.'
+				return
+			}
+			throw error
 		})
 }
 </script>
@@ -168,6 +183,8 @@ const onFormSubmit = () => {
 						v-model.number="amount"
 					/>
 
+					<div class="error" v-if="errorMessage">{{ errorMessage }}</div>
+
 					<div class="modal-actions">
 						<button
 							class="modal-button modal-button--primary"
@@ -234,6 +251,14 @@ const onFormSubmit = () => {
 	align-items: center;
 	gap: 6px;
 	cursor: pointer;
+}
+
+.error {
+	padding: 4px 8px;
+	border-radius: 6px;
+	background-color: #fef2f2;
+	font-size: 0.8125rem;
+	color: #291e1c;
 }
 
 .modal-actions {

--- a/src/views/Profile/components/TerritoryHoursForm.vue
+++ b/src/views/Profile/components/TerritoryHoursForm.vue
@@ -14,6 +14,7 @@ const showModal = ref(false)
 const reason = ref<TerritoryHourChangeSource>(TerritoryHourChangeSource.Seize)
 const seizeSliceIndex = ref<number | null>(null)
 const applyPenalty = ref(false)
+const targetLogin = ref<string | null>(null)
 const amount = ref<number | null>(null)
 
 const isSeize = computed(
@@ -44,11 +45,20 @@ watch(reason, (value) => {
 	}
 })
 
+watch(applyPenalty, (value) => {
+	if (value) {
+		if (!userStore.users) userStore.getAllUsers()
+	} else {
+		targetLogin.value = null
+	}
+})
+
 const closeModal = () => {
 	showModal.value = false
 	reason.value = TerritoryHourChangeSource.Seize
 	seizeSliceIndex.value = null
 	applyPenalty.value = false
+	targetLogin.value = null
 	amount.value = null
 }
 
@@ -72,9 +82,17 @@ const onFormSubmit = () => {
 		: amount.value
 
 	if (!desiredChangeValue) return
+	if (applyPenalty.value && !targetLogin.value) return
 
 	userStore
-		.changeTerritoryHours({ changeSource: reason.value, desiredChangeValue })
+		.changeTerritoryHours({
+			changeSource: reason.value,
+			desiredChangeValue,
+			isSomeones: applyPenalty.value,
+			...(applyPenalty.value && targetLogin.value
+				? { login: targetLogin.value }
+				: {}),
+		})
 		.then(() => {
 			closeModal()
 		})
@@ -123,6 +141,22 @@ const onFormSubmit = () => {
 							/>
 							Чужая территория
 						</label>
+
+						<select
+							v-if="applyPenalty"
+							class="reason-select"
+							:disabled="isLoading"
+							v-model="targetLogin"
+						>
+							<option :value="null" disabled>Выберите игрока</option>
+							<option
+								v-for="user in userStore.otherUsers"
+								:key="user.login"
+								:value="user.login"
+							>
+								{{ user.displayName ?? user.login }}
+							</option>
+						</select>
 					</template>
 
 					<input

--- a/src/views/Users/OtherUserProfileView.vue
+++ b/src/views/Users/OtherUserProfileView.vue
@@ -33,6 +33,9 @@ const currentGame = computed(
 	() => userStore.userCurrentGame[login.value] ?? null,
 )
 const pointsInfo = computed(() => userStore.userPoints[login.value] ?? null)
+const territoryPoints = computed(
+	() => userStore.userTerritoryPoints[login.value] ?? null,
+)
 const gamesHistory = computed(() => userStore.userHistory[login.value] ?? [])
 const effectsHistory = computed(() => userStore.userEffects[login.value] ?? [])
 const freeHistory = computed(
@@ -50,6 +53,7 @@ const freeLabelFor = (source: string) =>
 const loadAll = () => {
 	userStore.getUserCurrentGame(login.value)
 	userStore.getUserPoints(login.value)
+	userStore.getUserTerritoryPoints(login.value)
 	userStore.getUserHistory(login.value)
 	userStore.getUserEffects(login.value)
 	userStore.getUserFreePointsHistory(login.value)
@@ -86,10 +90,16 @@ watch(login, loadAll)
 				</div>
 			</div>
 
-			<div class="metrics-row" v-if="userStore.getUserPointsState.isLoaded">
+			<div
+				class="metrics-row"
+				v-if="
+					userStore.getUserPointsState.isLoaded &&
+					userStore.getUserTerritoryPointsState.isLoaded
+				"
+			>
 				<div class="metric-card">
 					<span class="metric-label">Очки территорий</span>
-					<div class="metric-value">{{ pointsInfo?.territoryPoints }}</div>
+					<div class="metric-value">{{ territoryPoints }}</div>
 				</div>
 				<div class="metric-card">
 					<span class="metric-label">Свободные очки</span>

--- a/src/views/Users/UsersView.vue
+++ b/src/views/Users/UsersView.vue
@@ -1,16 +1,10 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { onMounted } from 'vue'
 import UiView from '../../components/ui/UiView.vue'
-import { useAuthStore } from '../../stores/authStore'
 import { useFeatureUserStore } from '../../stores/feature/featureUserStore'
 import { RouteName } from '../../router/routeNames'
 
 const userStore = useFeatureUserStore()
-const authStore = useAuthStore()
-
-const otherUsers = computed(
-	() => userStore.users?.filter((u) => u.login !== authStore.login) ?? [],
-)
 
 onMounted(() => userStore.getAllUsers())
 </script>
@@ -24,7 +18,7 @@ onMounted(() => userStore.getAllUsers())
 		<template v-else>
 			<div class="users-grid">
 				<RouterLink
-					v-for="user in otherUsers"
+					v-for="user in userStore.otherUsers"
 					:key="user.login"
 					:to="{ name: RouteName.UserDetail, params: { login: user.login } }"
 					class="user-tile"


### PR DESCRIPTION
## Summary
- When changing territory hours with the "Foreign territory" checkbox checked, show a dropdown to pick the target player (excluding the current user) and send their login plus an isSomeones flag to the territory-hours endpoint.
- Update response models for the new per-point-type territory-hours response shape (no longer echoes changeSource/desiredChangeValue on write responses, kept on history entries).
- Fix the seize penalty amount not being included in the submitted value.
- Show an inline error message when the endpoint returns NOT_ENOUGH_CURRENT_POINTS.
- Refresh territory points and history for both the current user and the selected foreign player after a successful change, sourcing territory points from the dedicated endpoint instead of the combined points-info endpoint.
- Extract "other users" (all users excluding current) into featureUserStore to share between the form and the users list view.