### PR TITLE
Wheel effect apply: availableRolls support and form rework

### DIFF
--- a/src/api-facade/models/points-models.ts
+++ b/src/api-facade/models/points-models.ts
@@ -15,19 +15,24 @@ export type PointChangeResult = {
 	finalValue: number
 }
 
-export type PointChangeWithLogin = {
-	login: string
-	pointChange: PointChange
+export enum PointType {
+	FreePoints = 'freePoints',
+	TerritoryPoints = 'territoryPoints',
+	ExperiencePoints = 'experiencePoints',
+	AvailableRolls = 'availableRolls',
+	TerritoryHours = 'territoryHours',
 }
+
+export type PointChangeResults = Partial<Record<PointType, PointChangeResult>>
+
+export const getPointChangeResult = (
+	results: PointChangeResults,
+	type: PointType,
+) => results[type]
 
 export type TerritoryHourChange = PointChange & {
 	isSomeones: boolean
 	login?: string
-}
-
-export type TerritoryHourChangeResult = {
-	territoryHours?: PointChangeResult
-	territoryPoints?: PointChangeResult
 }
 
 export enum TerritoryChangeSource {

--- a/src/api-facade/models/wheel-effects-models.ts
+++ b/src/api-facade/models/wheel-effects-models.ts
@@ -1,8 +1,20 @@
 import { type DtoStringToDate } from '../dto-types'
+import type { PointChange, PointChangeResults } from './points-models'
 
 export type WheelEffect = {
 	name: string
 	description?: string
+}
+
+export type WheelEffectPointChange = {
+	login: string
+	freePointChange?: PointChange
+	availableRollChange?: PointChange
+}
+
+export type WheelEffectPointChangeResult = {
+	login: string
+	changeResults: PointChangeResults
 }
 
 export type RolledWheelEffectHistoryDto = WheelEffect & {

--- a/src/api-facade/requests/points-requests.ts
+++ b/src/api-facade/requests/points-requests.ts
@@ -4,9 +4,9 @@ import type {
 	FreePointChangeResult,
 	PointChange,
 	PointChangeResult,
+	PointChangeResults,
 	PointInfo,
 	TerritoryHourChange,
-	TerritoryHourChangeResult,
 	TerritoryPointChangeHistoryDto,
 	TerritoryPointChangeResult,
 } from '../models/points-models'
@@ -98,7 +98,7 @@ export type PostTerritoryHours = {
 	request: {
 		body: TerritoryHourChange
 	}
-	response: TerritoryHourChangeResult
+	response: PointChangeResults
 }
 
 export type GetTerritoryHours = {

--- a/src/api-facade/requests/wheel-effects-requests.ts
+++ b/src/api-facade/requests/wheel-effects-requests.ts
@@ -1,12 +1,10 @@
 import type { WheelResult } from '../../types/wheelResult.ts'
 import type {
-	FreePointChangeResult,
-	PointChangeWithLogin,
-} from '../models/points-models'
-import type {
 	RolledWheelEffectDto,
 	RolledWheelEffectHistoryDto,
 	WheelEffect,
+	WheelEffectPointChange,
+	WheelEffectPointChangeResult,
 } from '../models/wheel-effects-models'
 
 export type GetWheelEffectsHistory = {
@@ -37,12 +35,9 @@ export type GetLastRolledWheelEffects = {
 export type PostApplyWheelEffectRoll = {
 	request: {
 		body: {
-			pointChanges: PointChangeWithLogin[]
+			pointChanges: WheelEffectPointChange[]
 			wheelEffectName: string
 		}
 	}
-	response: {
-		login: string
-		changeResult: FreePointChangeResult
-	}[]
+	response: WheelEffectPointChangeResult[]
 }

--- a/src/components/ui/UiView.vue
+++ b/src/components/ui/UiView.vue
@@ -31,5 +31,6 @@
 	inline-size: 100%;
 
 	padding-block: 2rem;
+	padding-inline: 1rem;
 }
 </style>

--- a/src/stores/api/apiPointsStore.ts
+++ b/src/stores/api/apiPointsStore.ts
@@ -1,13 +1,15 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { api } from '../../api-facade/api'
-import type {
-	FreePointChange,
-	FreePointChangeHistory,
-	PointChange,
-	PointInfo,
-	TerritoryHourChange,
-	TerritoryPointChangeHistory,
+import {
+	getPointChangeResult,
+	PointType,
+	type FreePointChange,
+	type FreePointChangeHistory,
+	type PointChange,
+	type PointInfo,
+	type TerritoryHourChange,
+	type TerritoryPointChangeHistory,
 } from '../../api-facade/models/points-models'
 import { StoreName } from '../../enums/storeName'
 import { LoadingStatus, withLoading } from '../../utils/loadingState'
@@ -202,11 +204,19 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 			return api.points
 				.postTerritoryHours({ body: change })
 				.then((result) => {
-					if (result.territoryHours) {
-						territoryHours.value = result.territoryHours.finalValue
+					const territoryHoursResult = getPointChangeResult(
+						result,
+						PointType.TerritoryHours,
+					)
+					if (territoryHoursResult) {
+						territoryHours.value = territoryHoursResult.finalValue
 					}
 
-					if (result.territoryPoints) {
+					const territoryPointsResult = getPointChangeResult(
+						result,
+						PointType.TerritoryPoints,
+					)
+					if (territoryPointsResult) {
 						const affectedLogins = [authStore.login, change.login].filter(
 							(login): login is string => !!login,
 						)

--- a/src/stores/api/apiWheelStore.ts
+++ b/src/stores/api/apiWheelStore.ts
@@ -1,16 +1,22 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { api } from '../../api-facade/api'
-import type { PointChangeWithLogin } from '../../api-facade/models/points-models'
+import { PointType, getPointChangeResult } from '../../api-facade/models/points-models'
 import type {
 	RolledWheelEffectHistory,
 	WheelEffect,
+	WheelEffectPointChange,
 } from '../../api-facade/models/wheel-effects-models'
 import { StoreName } from '../../enums/storeName'
 import type { WheelResult } from '../../types/wheelResult.ts'
 import { LoadingStatus, withLoading } from '../../utils/loadingState'
+import { useAuthStore } from '../authStore'
+import { useApiPointsStore } from './apiPointsStore'
 
 export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
+	const authStore = useAuthStore()
+	const pointsStore = useApiPointsStore()
+
 	const availableRollCount = ref(0)
 	const effectsHistory = ref<
 		Record<string, RolledWheelEffectHistory[] | undefined>
@@ -123,7 +129,7 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 		async (
 			status,
 			effectName: string,
-			pointChanges: PointChangeWithLogin[],
+			pointChanges: WheelEffectPointChange[],
 		) => {
 			if (status.value === LoadingStatus.LOADING) return
 
@@ -136,7 +142,27 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 						pointChanges: pointChanges,
 					},
 				})
-				.then(() => {
+				.then((results) => {
+					for (const result of results) {
+						const availableRollsResult = getPointChangeResult(
+							result.changeResults,
+							PointType.AvailableRolls,
+						)
+						if (availableRollsResult && result.login === authStore.login) {
+							availableRollCount.value = availableRollsResult.finalValue
+						}
+
+						const freePointsResult = getPointChangeResult(
+							result.changeResults,
+							PointType.FreePoints,
+						)
+						if (freePointsResult) {
+							pointsStore.freePoints[result.login] =
+								freePointsResult.finalValue
+							pointsStore.getFreePointsHistory(result.login)
+						}
+					}
+
 					const effect = currentEffects.value?.find(
 						(e) => e.name === effectName,
 					)

--- a/src/views/Wheel/WheelView.vue
+++ b/src/views/Wheel/WheelView.vue
@@ -4,8 +4,12 @@ import { useFeatureWheelStore } from '../../stores/feature/featureWheelStore'
 import { computed, onMounted, ref } from 'vue'
 import { funnyEffects } from './constants/funnyEffects.ts'
 import UiView from '../../components/ui/UiView.vue'
-import type { RolledWheelEffectDto } from '../../api-facade/models/wheel-effects-models'
+import type {
+	RolledWheelEffectDto,
+	WheelEffectPointChange,
+} from '../../api-facade/models/wheel-effects-models'
 import { FreePointChangeSource } from '../../api-facade/models/points-models'
+import { type HttpErrorResponse } from '../../api-facade/http'
 import { formatInstant } from '../../utils/temporal'
 import { useAuthStore } from '../../stores/authStore'
 import { useFeatureUserStore } from '../../stores/feature/featureUserStore'
@@ -54,6 +58,8 @@ const onRollButtonClick = () => {
 const selectedEffect = ref<RolledWheelEffectDto | null>(null)
 const showApplyForm = ref(false)
 const pointChanges = ref<Record<string, number>>({})
+const rollChanges = ref<Record<string, number>>({})
+const errorMessage = ref<string>()
 
 const closeModal = () => {
 	selectedEffect.value = null
@@ -61,36 +67,77 @@ const closeModal = () => {
 }
 
 const openApplyForm = () => {
-	pointChanges.value = Object.fromEntries(
-		(wheelStore.users ?? []).map((user) => [user.login, 0]),
-	)
+	const logins = (wheelStore.users ?? []).map((user) => user.login)
+	pointChanges.value = Object.fromEntries(logins.map((login) => [login, 0]))
+	rollChanges.value = Object.fromEntries(logins.map((login) => [login, 0]))
+	errorMessage.value = undefined
 	showApplyForm.value = true
 }
 
 const clamp = (value: number) => Math.min(100, Math.max(-100, value))
+const clampRoll = (value: number) => Math.min(100, Math.max(0, value))
 
 const onPointInput = (login: string, event: Event) => {
 	const raw = Number((event.target as HTMLInputElement).value)
 	pointChanges.value[login] = clamp(isNaN(raw) ? 0 : raw)
 }
 
+const onRollInput = (login: string, event: Event) => {
+	const raw = Number((event.target as HTMLInputElement).value)
+	rollChanges.value[login] = clampRoll(isNaN(raw) ? 0 : raw)
+}
+
 const submitApply = async () => {
 	if (!selectedEffect.value) return
 
-	const changes = Object.entries(pointChanges.value)
-		.filter(([, value]) => value !== 0)
-		.map(([login, desiredChangeValue]) => ({
-			login,
-			pointChange: {
+	errorMessage.value = undefined
+
+	const logins = new Set([
+		...Object.keys(pointChanges.value),
+		...Object.keys(rollChanges.value),
+	])
+
+	const changes: WheelEffectPointChange[] = []
+
+	for (const login of logins) {
+		const desiredPointChangeValue = pointChanges.value[login]
+		const desiredRollChangeValue = rollChanges.value[login]
+
+		if (!desiredPointChangeValue && !desiredRollChangeValue) continue
+
+		const change: WheelEffectPointChange = { login }
+
+		if (desiredPointChangeValue) {
+			change.freePointChange = {
 				changeSource: FreePointChangeSource.WheelEffect,
-				desiredChangeValue,
-			},
-		}))
+				desiredChangeValue: desiredPointChangeValue,
+			}
+		}
 
-	await wheelStore.applyRoll(selectedEffect.value.name, changes)
-	showApplyForm.value = false
+		if (desiredRollChangeValue) {
+			change.availableRollChange = {
+				changeSource: FreePointChangeSource.WheelEffect,
+				desiredChangeValue: desiredRollChangeValue,
+			}
+		}
 
-	if (authStore.login) await userStore.getUserEffects(authStore.login)
+		changes.push(change)
+	}
+
+	await wheelStore
+		.applyRoll(selectedEffect.value.name, changes)
+		.then(async () => {
+			showApplyForm.value = false
+
+			if (authStore.login) await userStore.getUserEffects(authStore.login)
+		})
+		.catch((error: HttpErrorResponse) => {
+			if (error.body?.code === 'INCORRECT_CHANGE_SOURCE_VALUE') {
+				errorMessage.value = 'Нельзя отдавать отрицательное число попыток.'
+				return
+			}
+			throw error
+		})
 }
 
 onMounted(() => {
@@ -191,6 +238,11 @@ onMounted(() => {
 					<template v-else>
 						<h2 class="modal-title">Применить: {{ selectedEffect.name }}</h2>
 						<div class="users-list">
+							<div class="user-row user-row--header">
+								<span class="user-name"></span>
+								<span class="point-input">Очки</span>
+								<span class="point-input">Прокруты</span>
+							</div>
 							<div
 								v-for="user in wheelStore.users"
 								:key="user.login"
@@ -204,11 +256,22 @@ onMounted(() => {
 									type="number"
 									min="-100"
 									max="100"
+									title="Очки"
 									:value="pointChanges[user.login]"
 									@input="onPointInput(user.login, $event)"
 								/>
+								<input
+									class="point-input"
+									type="number"
+									min="0"
+									max="100"
+									title="Прокруты"
+									:value="rollChanges[user.login]"
+									@input="onRollInput(user.login, $event)"
+								/>
 							</div>
 						</div>
+						<div class="error" v-if="errorMessage">{{ errorMessage }}</div>
 						<div class="modal-actions">
 							<button
 								class="modal-button modal-button--primary"
@@ -434,11 +497,27 @@ onMounted(() => {
 	overflow-y: auto;
 }
 
+.error {
+	padding: 4px 8px;
+	border-radius: 6px;
+	background-color: #fef2f2;
+	font-size: 0.8125rem;
+	color: #291e1c;
+}
+
 .user-row {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: 12px;
+}
+
+.user-row--header .point-input {
+	border: none;
+	padding: 0;
+	text-align: center;
+	font-size: 0.75rem;
+	color: #64748b;
 }
 
 .user-name {

--- a/src/views/Wheel/WheelView.vue
+++ b/src/views/Wheel/WheelView.vue
@@ -4,12 +4,8 @@ import { useFeatureWheelStore } from '../../stores/feature/featureWheelStore'
 import { computed, onMounted, ref } from 'vue'
 import { funnyEffects } from './constants/funnyEffects.ts'
 import UiView from '../../components/ui/UiView.vue'
-import type {
-	RolledWheelEffectDto,
-	WheelEffectPointChange,
-} from '../../api-facade/models/wheel-effects-models'
-import { FreePointChangeSource } from '../../api-facade/models/points-models'
-import { type HttpErrorResponse } from '../../api-facade/http'
+import WheelEffectApplyForm from './components/WheelEffectApplyForm.vue'
+import type { RolledWheelEffectDto } from '../../api-facade/models/wheel-effects-models'
 import { formatInstant } from '../../utils/temporal'
 import { useAuthStore } from '../../stores/authStore'
 import { useFeatureUserStore } from '../../stores/feature/featureUserStore'
@@ -57,87 +53,10 @@ const onRollButtonClick = () => {
 
 const selectedEffect = ref<RolledWheelEffectDto | null>(null)
 const showApplyForm = ref(false)
-const pointChanges = ref<Record<string, number>>({})
-const rollChanges = ref<Record<string, number>>({})
-const errorMessage = ref<string>()
 
 const closeModal = () => {
 	selectedEffect.value = null
 	showApplyForm.value = false
-}
-
-const openApplyForm = () => {
-	const logins = (wheelStore.users ?? []).map((user) => user.login)
-	pointChanges.value = Object.fromEntries(logins.map((login) => [login, 0]))
-	rollChanges.value = Object.fromEntries(logins.map((login) => [login, 0]))
-	errorMessage.value = undefined
-	showApplyForm.value = true
-}
-
-const clamp = (value: number) => Math.min(100, Math.max(-100, value))
-const clampRoll = (value: number) => Math.min(100, Math.max(0, value))
-
-const onPointInput = (login: string, event: Event) => {
-	const raw = Number((event.target as HTMLInputElement).value)
-	pointChanges.value[login] = clamp(isNaN(raw) ? 0 : raw)
-}
-
-const onRollInput = (login: string, event: Event) => {
-	const raw = Number((event.target as HTMLInputElement).value)
-	rollChanges.value[login] = clampRoll(isNaN(raw) ? 0 : raw)
-}
-
-const submitApply = async () => {
-	if (!selectedEffect.value) return
-
-	errorMessage.value = undefined
-
-	const logins = new Set([
-		...Object.keys(pointChanges.value),
-		...Object.keys(rollChanges.value),
-	])
-
-	const changes: WheelEffectPointChange[] = []
-
-	for (const login of logins) {
-		const desiredPointChangeValue = pointChanges.value[login]
-		const desiredRollChangeValue = rollChanges.value[login]
-
-		if (!desiredPointChangeValue && !desiredRollChangeValue) continue
-
-		const change: WheelEffectPointChange = { login }
-
-		if (desiredPointChangeValue) {
-			change.freePointChange = {
-				changeSource: FreePointChangeSource.WheelEffect,
-				desiredChangeValue: desiredPointChangeValue,
-			}
-		}
-
-		if (desiredRollChangeValue) {
-			change.availableRollChange = {
-				changeSource: FreePointChangeSource.WheelEffect,
-				desiredChangeValue: desiredRollChangeValue,
-			}
-		}
-
-		changes.push(change)
-	}
-
-	await wheelStore
-		.applyRoll(selectedEffect.value.name, changes)
-		.then(async () => {
-			showApplyForm.value = false
-
-			if (authStore.login) await userStore.getUserEffects(authStore.login)
-		})
-		.catch((error: HttpErrorResponse) => {
-			if (error.body?.code === 'INCORRECT_CHANGE_SOURCE_VALUE') {
-				errorMessage.value = 'Нельзя отдавать отрицательное число попыток.'
-				return
-			}
-			throw error
-		})
 }
 
 onMounted(() => {
@@ -227,7 +146,7 @@ onMounted(() => {
 							<button
 								v-if="!selectedEffect.isApplied"
 								class="modal-button modal-button--primary"
-								@click="openApplyForm"
+								@click="showApplyForm = true"
 							>
 								Применить
 							</button>
@@ -235,56 +154,11 @@ onMounted(() => {
 						</div>
 					</template>
 
-					<template v-else>
-						<h2 class="modal-title">Применить: {{ selectedEffect.name }}</h2>
-						<div class="users-list">
-							<div class="user-row user-row--header">
-								<span class="user-name"></span>
-								<span class="point-input">Очки</span>
-								<span class="point-input">Прокруты</span>
-							</div>
-							<div
-								v-for="user in wheelStore.users"
-								:key="user.login"
-								class="user-row"
-							>
-								<span class="user-name">{{
-									user.displayName ?? user.login
-								}}</span>
-								<input
-									class="point-input"
-									type="number"
-									min="-100"
-									max="100"
-									title="Очки"
-									:value="pointChanges[user.login]"
-									@input="onPointInput(user.login, $event)"
-								/>
-								<input
-									class="point-input"
-									type="number"
-									min="0"
-									max="100"
-									title="Прокруты"
-									:value="rollChanges[user.login]"
-									@input="onRollInput(user.login, $event)"
-								/>
-							</div>
-						</div>
-						<div class="error" v-if="errorMessage">{{ errorMessage }}</div>
-						<div class="modal-actions">
-							<button
-								class="modal-button modal-button--primary"
-								:disabled="wheelStore.applyRollState.isLoading"
-								@click="submitApply"
-							>
-								Подтвердить
-							</button>
-							<button class="modal-button" @click="showApplyForm = false">
-								Назад
-							</button>
-						</div>
-					</template>
+					<WheelEffectApplyForm
+						v-else
+						:effect="selectedEffect"
+						@close="showApplyForm = false"
+					/>
 				</div>
 			</div>
 		</Teleport>
@@ -487,51 +361,5 @@ onMounted(() => {
 
 .modal-button--primary:hover:not(:disabled) {
 	background-color: #2563eb;
-}
-
-.users-list {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-	max-height: 300px;
-	overflow-y: auto;
-}
-
-.error {
-	padding: 4px 8px;
-	border-radius: 6px;
-	background-color: #fef2f2;
-	font-size: 0.8125rem;
-	color: #291e1c;
-}
-
-.user-row {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 12px;
-}
-
-.user-row--header .point-input {
-	border: none;
-	padding: 0;
-	text-align: center;
-	font-size: 0.75rem;
-	color: #64748b;
-}
-
-.user-name {
-	flex: 1;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.point-input {
-	width: 72px;
-	padding: 4px 8px;
-	border: 1px solid #cbd5e1;
-	border-radius: 4px;
-	text-align: right;
 }
 </style>

--- a/src/views/Wheel/WheelView.vue
+++ b/src/views/Wheel/WheelView.vue
@@ -127,7 +127,7 @@ onMounted(() => {
 
 		<Teleport to="body">
 			<div v-if="selectedEffect" class="modal-overlay" @click.self="closeModal">
-				<div class="modal">
+				<div class="modal" :class="{ 'modal--wide': showApplyForm }">
 					<template v-if="!showApplyForm">
 						<h2 class="modal-title">{{ selectedEffect.name }}</h2>
 						<p v-if="selectedEffect.description" class="modal-description">
@@ -310,9 +310,15 @@ onMounted(() => {
 	padding: 24px;
 	max-width: 400px;
 	width: 90%;
+	max-height: 85vh;
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
+	overflow-y: auto;
+}
+
+.modal--wide {
+	max-width: 720px;
 }
 
 .modal-title {

--- a/src/views/Wheel/components/WheelEffectApplyForm.vue
+++ b/src/views/Wheel/components/WheelEffectApplyForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import type { HttpErrorResponse } from '../../../api-facade/http'
 import { FreePointChangeSource } from '../../../api-facade/models/points-models'
 import type {
@@ -22,45 +22,89 @@ const wheelStore = useFeatureWheelStore()
 const authStore = useAuthStore()
 const userStore = useFeatureUserStore()
 
-const pointChanges = ref<Record<string, number>>(
-	Object.fromEntries((wheelStore.users ?? []).map((user) => [user.login, 0])),
-)
-const rollChanges = ref<Record<string, number>>(
-	Object.fromEntries((wheelStore.users ?? []).map((user) => [user.login, 0])),
-)
+type OtherPlayerRow = {
+	id: number
+	login: string | null
+	pointChange: number
+	rollChange: number
+}
+
+const currentPointChange = ref(0)
+const currentRollChange = ref(0)
+const otherRows = ref<OtherPlayerRow[]>([])
 const errorMessage = ref<string>()
+
+let nextRowId = 0
+
+const otherUsers = computed(() =>
+	(wheelStore.users ?? []).filter((user) => user.login !== authStore.login),
+)
+
+const availableLoginsForRow = (row: OtherPlayerRow) =>
+	otherUsers.value.filter(
+		(user) =>
+			user.login === row.login ||
+			!otherRows.value.some(
+				(other) => other !== row && other.login === user.login,
+			),
+	)
+
+const addOtherRow = () => {
+	otherRows.value.push({
+		id: nextRowId++,
+		login: null,
+		pointChange: 0,
+		rollChange: 0,
+	})
+}
+
+const removeOtherRow = (id: number) => {
+	otherRows.value = otherRows.value.filter((row) => row.id !== id)
+}
 
 const clamp = (value: number) => Math.min(100, Math.max(-100, value))
 const clampRoll = (value: number) => Math.min(100, Math.max(0, value))
 
-const onPointInput = (login: string, event: Event) => {
+const parseInputValue = (event: Event) => {
 	const raw = Number((event.target as HTMLInputElement).value)
-	pointChanges.value[login] = clamp(isNaN(raw) ? 0 : raw)
+	return isNaN(raw) ? 0 : raw
 }
 
-const onRollInput = (login: string, event: Event) => {
-	const raw = Number((event.target as HTMLInputElement).value)
-	rollChanges.value[login] = clampRoll(isNaN(raw) ? 0 : raw)
+const onCurrentPointInput = (event: Event) => {
+	currentPointChange.value = clamp(parseInputValue(event))
 }
 
-const buildChange = (login: string): WheelEffectPointChange | null => {
-	const desiredPointChangeValue = pointChanges.value[login]
-	const desiredRollChangeValue = rollChanges.value[login]
+const onCurrentRollInput = (event: Event) => {
+	currentRollChange.value = clampRoll(parseInputValue(event))
+}
 
-	if (!desiredPointChangeValue && !desiredRollChangeValue) return null
+const onOtherPointInput = (row: OtherPlayerRow, event: Event) => {
+	row.pointChange = clamp(parseInputValue(event))
+}
+
+const onOtherRollInput = (row: OtherPlayerRow, event: Event) => {
+	row.rollChange = clampRoll(parseInputValue(event))
+}
+
+const buildChange = (
+	login: string,
+	pointChange: number,
+	rollChange: number,
+): WheelEffectPointChange | null => {
+	if (!pointChange && !rollChange) return null
 
 	return {
 		login,
-		...(desiredPointChangeValue && {
+		...(pointChange && {
 			freePointChange: {
 				changeSource: FreePointChangeSource.WheelEffect,
-				desiredChangeValue: desiredPointChangeValue,
+				desiredChangeValue: pointChange,
 			},
 		}),
-		...(desiredRollChangeValue && {
+		...(rollChange && {
 			availableRollChange: {
 				changeSource: FreePointChangeSource.WheelEffect,
-				desiredChangeValue: desiredRollChangeValue,
+				desiredChangeValue: rollChange,
 			},
 		}),
 	}
@@ -69,9 +113,23 @@ const buildChange = (login: string): WheelEffectPointChange | null => {
 const submitApply = async () => {
 	errorMessage.value = undefined
 
-	const changes = Object.keys(pointChanges.value)
-		.map(buildChange)
-		.filter((change): change is WheelEffectPointChange => change !== null)
+	const changes: WheelEffectPointChange[] = []
+
+	if (authStore.login) {
+		const change = buildChange(
+			authStore.login,
+			currentPointChange.value,
+			currentRollChange.value,
+		)
+		if (change) changes.push(change)
+	}
+
+	for (const row of otherRows.value) {
+		if (!row.login) continue
+
+		const change = buildChange(row.login, row.pointChange, row.rollChange)
+		if (change) changes.push(change)
+	}
 
 	await wheelStore
 		.applyRoll(props.effect.name, changes)
@@ -96,17 +154,21 @@ const submitApply = async () => {
 			<span class="user-name"></span>
 			<span class="point-input">Очки</span>
 			<span class="point-input">Прокруты</span>
+			<span class="row-action"></span>
 		</div>
-		<div v-for="user in wheelStore.users" :key="user.login" class="user-row">
-			<span class="user-name">{{ user.displayName ?? user.login }}</span>
+
+		<div class="user-row">
+			<span class="user-name">{{
+				userStore.currentUser.displayName ?? userStore.currentUser.login
+			}}</span>
 			<input
 				class="point-input"
 				type="number"
 				min="-100"
 				max="100"
 				title="Очки"
-				:value="pointChanges[user.login]"
-				@input="onPointInput(user.login, $event)"
+				:value="currentPointChange"
+				@input="onCurrentPointInput"
 			/>
 			<input
 				class="point-input"
@@ -114,11 +176,60 @@ const submitApply = async () => {
 				min="0"
 				max="100"
 				title="Прокруты"
-				:value="rollChanges[user.login]"
-				@input="onRollInput(user.login, $event)"
+				:value="currentRollChange"
+				@input="onCurrentRollInput"
 			/>
+			<span class="row-action"></span>
+		</div>
+
+		<div v-for="row in otherRows" :key="row.id" class="user-row">
+			<select class="user-select" v-model="row.login">
+				<option :value="null" disabled>Выберите игрока</option>
+				<option
+					v-for="user in availableLoginsForRow(row)"
+					:key="user.login"
+					:value="user.login"
+				>
+					{{ user.displayName ?? user.login }}
+				</option>
+			</select>
+			<input
+				class="point-input"
+				type="number"
+				min="-100"
+				max="100"
+				title="Очки"
+				:value="row.pointChange"
+				@input="onOtherPointInput(row, $event)"
+			/>
+			<input
+				class="point-input"
+				type="number"
+				min="0"
+				max="100"
+				title="Прокруты"
+				:value="row.rollChange"
+				@input="onOtherRollInput(row, $event)"
+			/>
+			<button
+				class="row-action remove-row-button"
+				type="button"
+				@click="removeOtherRow(row.id)"
+			>
+				✕
+			</button>
 		</div>
 	</div>
+
+	<button
+		class="modal-button add-row-button"
+		type="button"
+		:disabled="otherRows.length >= otherUsers.length"
+		@click="addOtherRow"
+	>
+		+ Добавить игрока
+	</button>
+
 	<div class="error" v-if="errorMessage">{{ errorMessage }}</div>
 	<div class="modal-actions">
 		<button
@@ -171,6 +282,10 @@ const submitApply = async () => {
 	background-color: #2563eb;
 }
 
+.add-row-button {
+	align-self: flex-start;
+}
+
 .users-list {
 	display: flex;
 	flex-direction: column;
@@ -204,9 +319,19 @@ const submitApply = async () => {
 
 .user-name {
 	flex: 1;
+	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.user-select {
+	flex: 1;
+	min-width: 0;
+	border-radius: 4px;
+	border: 1px solid #cbd5e1;
+	background-color: #fff;
+	padding: 4px 8px;
 }
 
 .point-input {
@@ -215,5 +340,23 @@ const submitApply = async () => {
 	border: 1px solid #cbd5e1;
 	border-radius: 4px;
 	text-align: right;
+}
+
+.row-action {
+	width: 20px;
+	text-align: center;
+}
+
+.remove-row-button {
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	color: #64748b;
+	font-size: 0.875rem;
+	padding: 0;
+}
+
+.remove-row-button:hover {
+	color: #ef4444;
 }
 </style>

--- a/src/views/Wheel/components/WheelEffectApplyForm.vue
+++ b/src/views/Wheel/components/WheelEffectApplyForm.vue
@@ -43,40 +43,35 @@ const onRollInput = (login: string, event: Event) => {
 	rollChanges.value[login] = clampRoll(isNaN(raw) ? 0 : raw)
 }
 
+const buildChange = (login: string): WheelEffectPointChange | null => {
+	const desiredPointChangeValue = pointChanges.value[login]
+	const desiredRollChangeValue = rollChanges.value[login]
+
+	if (!desiredPointChangeValue && !desiredRollChangeValue) return null
+
+	return {
+		login,
+		...(desiredPointChangeValue && {
+			freePointChange: {
+				changeSource: FreePointChangeSource.WheelEffect,
+				desiredChangeValue: desiredPointChangeValue,
+			},
+		}),
+		...(desiredRollChangeValue && {
+			availableRollChange: {
+				changeSource: FreePointChangeSource.WheelEffect,
+				desiredChangeValue: desiredRollChangeValue,
+			},
+		}),
+	}
+}
+
 const submitApply = async () => {
 	errorMessage.value = undefined
 
-	const logins = new Set([
-		...Object.keys(pointChanges.value),
-		...Object.keys(rollChanges.value),
-	])
-
-	const changes: WheelEffectPointChange[] = []
-
-	for (const login of logins) {
-		const desiredPointChangeValue = pointChanges.value[login]
-		const desiredRollChangeValue = rollChanges.value[login]
-
-		if (!desiredPointChangeValue && !desiredRollChangeValue) continue
-
-		const change: WheelEffectPointChange = { login }
-
-		if (desiredPointChangeValue) {
-			change.freePointChange = {
-				changeSource: FreePointChangeSource.WheelEffect,
-				desiredChangeValue: desiredPointChangeValue,
-			}
-		}
-
-		if (desiredRollChangeValue) {
-			change.availableRollChange = {
-				changeSource: FreePointChangeSource.WheelEffect,
-				desiredChangeValue: desiredRollChangeValue,
-			}
-		}
-
-		changes.push(change)
-	}
+	const changes = Object.keys(pointChanges.value)
+		.map(buildChange)
+		.filter((change): change is WheelEffectPointChange => change !== null)
 
 	await wheelStore
 		.applyRoll(props.effect.name, changes)

--- a/src/views/Wheel/components/WheelEffectApplyForm.vue
+++ b/src/views/Wheel/components/WheelEffectApplyForm.vue
@@ -1,0 +1,224 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { HttpErrorResponse } from '../../../api-facade/http'
+import { FreePointChangeSource } from '../../../api-facade/models/points-models'
+import type {
+	RolledWheelEffectDto,
+	WheelEffectPointChange,
+} from '../../../api-facade/models/wheel-effects-models'
+import { useAuthStore } from '../../../stores/authStore'
+import { useFeatureUserStore } from '../../../stores/feature/featureUserStore'
+import { useFeatureWheelStore } from '../../../stores/feature/featureWheelStore'
+
+const props = defineProps<{
+	effect: RolledWheelEffectDto
+}>()
+
+const emit = defineEmits<{
+	close: []
+}>()
+
+const wheelStore = useFeatureWheelStore()
+const authStore = useAuthStore()
+const userStore = useFeatureUserStore()
+
+const pointChanges = ref<Record<string, number>>(
+	Object.fromEntries((wheelStore.users ?? []).map((user) => [user.login, 0])),
+)
+const rollChanges = ref<Record<string, number>>(
+	Object.fromEntries((wheelStore.users ?? []).map((user) => [user.login, 0])),
+)
+const errorMessage = ref<string>()
+
+const clamp = (value: number) => Math.min(100, Math.max(-100, value))
+const clampRoll = (value: number) => Math.min(100, Math.max(0, value))
+
+const onPointInput = (login: string, event: Event) => {
+	const raw = Number((event.target as HTMLInputElement).value)
+	pointChanges.value[login] = clamp(isNaN(raw) ? 0 : raw)
+}
+
+const onRollInput = (login: string, event: Event) => {
+	const raw = Number((event.target as HTMLInputElement).value)
+	rollChanges.value[login] = clampRoll(isNaN(raw) ? 0 : raw)
+}
+
+const submitApply = async () => {
+	errorMessage.value = undefined
+
+	const logins = new Set([
+		...Object.keys(pointChanges.value),
+		...Object.keys(rollChanges.value),
+	])
+
+	const changes: WheelEffectPointChange[] = []
+
+	for (const login of logins) {
+		const desiredPointChangeValue = pointChanges.value[login]
+		const desiredRollChangeValue = rollChanges.value[login]
+
+		if (!desiredPointChangeValue && !desiredRollChangeValue) continue
+
+		const change: WheelEffectPointChange = { login }
+
+		if (desiredPointChangeValue) {
+			change.freePointChange = {
+				changeSource: FreePointChangeSource.WheelEffect,
+				desiredChangeValue: desiredPointChangeValue,
+			}
+		}
+
+		if (desiredRollChangeValue) {
+			change.availableRollChange = {
+				changeSource: FreePointChangeSource.WheelEffect,
+				desiredChangeValue: desiredRollChangeValue,
+			}
+		}
+
+		changes.push(change)
+	}
+
+	await wheelStore
+		.applyRoll(props.effect.name, changes)
+		.then(async () => {
+			if (authStore.login) await userStore.getUserEffects(authStore.login)
+			emit('close')
+		})
+		.catch((error: HttpErrorResponse) => {
+			if (error.body?.code === 'INCORRECT_CHANGE_SOURCE_VALUE') {
+				errorMessage.value = 'Значение перекрутов должно быть 0 или больше.'
+				return
+			}
+			throw error
+		})
+}
+</script>
+
+<template>
+	<h2 class="modal-title">Применить: {{ effect.name }}</h2>
+	<div class="users-list">
+		<div class="user-row user-row--header">
+			<span class="user-name"></span>
+			<span class="point-input">Очки</span>
+			<span class="point-input">Прокруты</span>
+		</div>
+		<div v-for="user in wheelStore.users" :key="user.login" class="user-row">
+			<span class="user-name">{{ user.displayName ?? user.login }}</span>
+			<input
+				class="point-input"
+				type="number"
+				min="-100"
+				max="100"
+				title="Очки"
+				:value="pointChanges[user.login]"
+				@input="onPointInput(user.login, $event)"
+			/>
+			<input
+				class="point-input"
+				type="number"
+				min="0"
+				max="100"
+				title="Прокруты"
+				:value="rollChanges[user.login]"
+				@input="onRollInput(user.login, $event)"
+			/>
+		</div>
+	</div>
+	<div class="error" v-if="errorMessage">{{ errorMessage }}</div>
+	<div class="modal-actions">
+		<button
+			class="modal-button modal-button--primary"
+			:disabled="wheelStore.applyRollState.isLoading"
+			@click="submitApply"
+		>
+			Подтвердить
+		</button>
+		<button class="modal-button" @click="emit('close')">Назад</button>
+	</div>
+</template>
+
+<style scoped>
+.modal-title {
+	font-size: 1.25rem;
+	font-weight: 600;
+}
+
+.modal-actions {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-end;
+}
+
+.modal-button {
+	padding: 6px 16px;
+	border: 1px solid #64748b;
+	border-radius: 4px;
+	cursor: pointer;
+	background: transparent;
+}
+
+.modal-button:hover:not(:disabled) {
+	background-color: #f1f5f9;
+}
+
+.modal-button:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.modal-button--primary {
+	background-color: #3b82f6;
+	border-color: #3b82f6;
+	color: #fff;
+}
+
+.modal-button--primary:hover:not(:disabled) {
+	background-color: #2563eb;
+}
+
+.users-list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-height: 300px;
+	overflow-y: auto;
+}
+
+.error {
+	padding: 4px 8px;
+	border-radius: 6px;
+	background-color: #fef2f2;
+	font-size: 0.8125rem;
+	color: #291e1c;
+}
+
+.user-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.user-row--header .point-input {
+	border: none;
+	padding: 0;
+	text-align: center;
+	font-size: 0.75rem;
+	color: #64748b;
+}
+
+.user-name {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.point-input {
+	width: 72px;
+	padding: 4px 8px;
+	border: 1px solid #cbd5e1;
+	border-radius: 4px;
+	text-align: right;
+}
+</style>


### PR DESCRIPTION
## Summary
- Adapt wheel effect apply (`/wheel-effects/available/roll/apply`) and territory hours change to the new `changeResults` map response format, via a shared `PointType`/`PointChangeResults`/`getPointChangeResult` helper.
- Let admins grant `availableRolls` alongside free points when applying a wheel effect, with client-side and server-error validation against negative values.
- Extract the apply form into its own `WheelEffectApplyForm.vue` component, simplify its change-building logic, and rework it so the current player is always shown while other players are added one at a time via a dropdown (no duplicate logins) with a remove button.
- Add horizontal padding to the shared `UiView` page layout.