### PR TITLE
Add reroll option to wheel roll

### DIFF
--- a/src/api-facade/api/apiWheelEffects.ts
+++ b/src/api-facade/api/apiWheelEffects.ts
@@ -23,9 +23,11 @@ export const apiWheelEffects = {
 			.get<GetWheelEffectsAvailable>('/wheel-effects/available')
 			.then(({ body }) => body),
 
-	postRoll: (): Promise<WheelResult> =>
+	postRoll: (isReroll: boolean): Promise<WheelResult> =>
 		http
-			.post<PostRollWheelEffect>('/wheel-effects/available/roll')
+			.post<PostRollWheelEffect>('/wheel-effects/available/roll', {
+				body: { isReroll },
+			})
 			.then(({ body }) => body as WheelResult),
 
 	getAvailableCount: () =>

--- a/src/api-facade/requests/wheel-effects-requests.ts
+++ b/src/api-facade/requests/wheel-effects-requests.ts
@@ -21,6 +21,11 @@ export type GetWheelEffectsAvailable = {
 }
 
 export type PostRollWheelEffect = {
+	request: {
+		body: {
+			isReroll: boolean
+		}
+	}
 	response: RolledWheelEffectDto[]
 }
 

--- a/src/stores/api/apiWheelStore.ts
+++ b/src/stores/api/apiWheelStore.ts
@@ -64,7 +64,12 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 	)
 
 	const [roll, rollState] = withLoading(
-		async (status, minimum: number, change: number) => {
+		async (
+			status,
+			minimum: number,
+			change: number,
+			isReroll: boolean = false,
+		) => {
 			if (availableRollCount.value < minimum) {
 				return Promise.reject(
 					`Not enough available rolls (minimum: ${minimum})`,
@@ -75,10 +80,10 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 			status.value = LoadingStatus.LOADING
 
 			await api.wheelEffects
-				.postRoll()
+				.postRoll(isReroll)
 				.then((effects) => {
 					currentEffects.value = effects
-					availableRollCount.value += change
+					if (!isReroll) availableRollCount.value += change
 					status.value = LoadingStatus.LOADED
 				})
 				.catch((e) => {

--- a/src/stores/feature/featureWheelStore.ts
+++ b/src/stores/feature/featureWheelStore.ts
@@ -33,10 +33,11 @@ export const useFeatureWheelStore = defineStore(StoreName.FeatureWheel, () => {
 
 	const getAvailableEffects = () => wheelStore.getAvailableEffects()
 
-	const roll = () =>
+	const roll = (isReroll: boolean = false) =>
 		wheelStore.roll(
 			systemParametersStore.minimumAvailableRollCountForRoll,
 			systemParametersStore.availableRollChangeByRoll,
+			isReroll,
 		)
 
 	const getLastRoll = () => wheelStore.getLastRoll()

--- a/src/views/Wheel/WheelView.vue
+++ b/src/views/Wheel/WheelView.vue
@@ -47,8 +47,10 @@ const centerIndex = computed(() =>
 	Math.floor((visibleEffects.value.length - 1) / 2),
 )
 
+const isReroll = ref(false)
+
 const onRollButtonClick = () => {
-	wheelStore.roll()
+	wheelStore.roll(isReroll.value)
 }
 
 const selectedEffect = ref<RolledWheelEffectDto | null>(null)
@@ -97,13 +99,28 @@ onMounted(() => {
 				<div class="reel-pointer"></div>
 			</div>
 
-			<UiButton
-				class="roll-button"
-				:disabled="!wheelStore.availableRollCount"
-				@click="onRollButtonClick"
-			>
-				Прокрутить
-			</UiButton>
+			<div class="roll-controls">
+				<div class="roll-spacer"></div>
+
+				<UiButton
+					class="roll-button"
+					:disabled="!wheelStore.availableRollCount"
+					@click="onRollButtonClick"
+				>
+					{{ isReroll ? 'Перекрутить' : 'Прокрутить' }}
+				</UiButton>
+
+				<div class="roll-extra">
+					<label class="reroll-checkbox">
+						<input type="checkbox" v-model="isReroll" />
+						Перекрутить
+					</label>
+
+					<p v-if="isReroll" class="reroll-message">
+						Прокруты не будут потрачены
+					</p>
+				</div>
+			</div>
 
 			<h2 class="history-title">История применённых эффектов</h2>
 			<p v-if="userStore.getUserEffectsState.isLoading">Загрузка...</p>
@@ -245,10 +262,46 @@ onMounted(() => {
 	border-right: 12px solid #64748b;
 }
 
+.roll-controls {
+	display: grid;
+	grid-template-columns: 1fr auto 1fr;
+	align-items: center;
+	column-gap: 16px;
+}
+
+.roll-spacer {
+	grid-column: 1;
+}
+
 .roll-button {
+	grid-column: 2;
 	height: 56px;
 	width: 224px;
-	align-self: center;
+}
+
+.roll-extra {
+	grid-column: 3;
+	position: relative;
+	justify-self: start;
+}
+
+.reroll-checkbox {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 0.875rem;
+	color: #334155;
+	cursor: pointer;
+}
+
+.reroll-message {
+	position: absolute;
+	top: 100%;
+	left: 0;
+	margin-top: 4px;
+	font-size: 0.8125rem;
+	color: #64748b;
+	white-space: nowrap;
 }
 
 .history-title {


### PR DESCRIPTION
## Summary
- Adds an `isReroll` flag to the wheel roll request, letting the frontend request a reroll that does not consume прокруты
- Adds a checkbox next to the roll button; when checked, the button label switches to "Перекрутить" and a message clarifies that прокруты won't be spent