### PR TITLE
Sync all point fields for current player from endpoint responses

### DIFF
--- a/src/stores/api/apiPointsStore.ts
+++ b/src/stores/api/apiPointsStore.ts
@@ -20,7 +20,9 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 
 	const pointsInfo = ref<Record<string, PointInfo>>({})
 	const freePointsHistory = ref<Record<string, FreePointChangeHistory[]>>({})
-	const territoryPointsHistory = ref<Record<string, TerritoryPointChangeHistory[]>>({})
+	const territoryPointsHistory = ref<
+		Record<string, TerritoryPointChangeHistory[]>
+	>({})
 
 	const experiencePoints = ref<number | null>(null)
 	const territoryHours = ref<number | null>(null)
@@ -69,8 +71,8 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 		},
 	)
 
-	const [getTerritoryPointsHistory, getTerritoryPointsHistoryState] = withLoading(
-		async (status, login: string) => {
+	const [getTerritoryPointsHistory, getTerritoryPointsHistoryState] =
+		withLoading(async (status, login: string) => {
 			if (status.value === LoadingStatus.LOADING) return
 
 			status.value = LoadingStatus.LOADING
@@ -87,8 +89,7 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 					status.value = LoadingStatus.ERROR
 					throw e
 				})
-		},
-	)
+		})
 
 	const [getExperiencePoints, getExperiencePointsState] = withLoading(
 		async (status) => {
@@ -226,6 +227,9 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 								.getTerritoryPoints({ path: { login: affectedLogin } })
 								.then((value) => {
 									territoryPoints.value[affectedLogin] = value
+									if (pointsInfo.value[affectedLogin]) {
+										pointsInfo.value[affectedLogin].territoryPoints = value
+									}
 								})
 							api.points
 								.getTerritoryPointsHistory({ path: { login: affectedLogin } })
@@ -233,6 +237,40 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 									territoryPointsHistory.value[affectedLogin] = history
 								})
 						}
+					}
+
+					const freePointsResult = getPointChangeResult(
+						result,
+						PointType.FreePoints,
+					)
+					if (freePointsResult) {
+						const affectedLogins = [authStore.login, change.login].filter(
+							(login): login is string => !!login,
+						)
+
+						for (const affectedLogin of affectedLogins) {
+							api.points
+								.getFreePoints({ path: { login: affectedLogin } })
+								.then((value) => {
+									freePoints.value[affectedLogin] = value
+									if (pointsInfo.value[affectedLogin]) {
+										pointsInfo.value[affectedLogin].freePoints = value
+									}
+								})
+							api.points
+								.getFreePointsHistory({ path: { login: affectedLogin } })
+								.then((history) => {
+									freePointsHistory.value[affectedLogin] = history
+								})
+						}
+					}
+
+					const experiencePointsResult = getPointChangeResult(
+						result,
+						PointType.ExperiencePoints,
+					)
+					if (experiencePointsResult) {
+						experiencePoints.value = experiencePointsResult.finalValue
 					}
 
 					status.value = LoadingStatus.LOADED
@@ -256,6 +294,9 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 				.postTerritoryPoints({ body: change, path: { login } })
 				.then((result) => {
 					territoryPoints.value[login] = result.finalValue
+					if (pointsInfo.value[login]) {
+						pointsInfo.value[login].territoryPoints = result.finalValue
+					}
 
 					api.points
 						.getTerritoryPointsHistory({ path: { login } })
@@ -284,6 +325,9 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 				.postFreePoints({ body: change, path: { login } })
 				.then((result) => {
 					freePoints.value[login] = result.finalValue
+					if (pointsInfo.value[login]) {
+						pointsInfo.value[login].freePoints = result.finalValue
+					}
 
 					api.points
 						.getFreePointsHistory({ path: { login } })

--- a/src/stores/api/apiWheelStore.ts
+++ b/src/stores/api/apiWheelStore.ts
@@ -1,7 +1,10 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { api } from '../../api-facade/api'
-import { PointType, getPointChangeResult } from '../../api-facade/models/points-models'
+import {
+	PointType,
+	getPointChangeResult,
+} from '../../api-facade/models/points-models'
 import type {
 	RolledWheelEffectHistory,
 	WheelEffect,
@@ -179,9 +182,42 @@ export const useApiWheelStore = defineStore(StoreName.ApiWheel, () => {
 							PointType.FreePoints,
 						)
 						if (freePointsResult) {
-							pointsStore.freePoints[result.login] =
-								freePointsResult.finalValue
+							pointsStore.freePoints[result.login] = freePointsResult.finalValue
+							if (pointsStore.pointsInfo[result.login]) {
+								pointsStore.pointsInfo[result.login].freePoints =
+									freePointsResult.finalValue
+							}
 							pointsStore.getFreePointsHistory(result.login)
+						}
+
+						const territoryPointsResult = getPointChangeResult(
+							result.changeResults,
+							PointType.TerritoryPoints,
+						)
+						if (territoryPointsResult) {
+							pointsStore.territoryPoints[result.login] =
+								territoryPointsResult.finalValue
+							if (pointsStore.pointsInfo[result.login]) {
+								pointsStore.pointsInfo[result.login].territoryPoints =
+									territoryPointsResult.finalValue
+							}
+							pointsStore.getTerritoryPointsHistory(result.login)
+						}
+
+						const experiencePointsResult = getPointChangeResult(
+							result.changeResults,
+							PointType.ExperiencePoints,
+						)
+						if (experiencePointsResult && result.login === authStore.login) {
+							pointsStore.experiencePoints = experiencePointsResult.finalValue
+						}
+
+						const territoryHoursResult = getPointChangeResult(
+							result.changeResults,
+							PointType.TerritoryHours,
+						)
+						if (territoryHoursResult && result.login === authStore.login) {
+							pointsStore.territoryHours = territoryHoursResult.finalValue
 						}
 					}
 


### PR DESCRIPTION
## Summary
- `postTerritoryHours` and wheel effect `applyRoll` responses can carry changes to multiple point types (free points, territory points, experience points, territory hours), but the handlers only applied a subset of them to local state.
- The profile views display free points from a separate cached `pointsInfo` snapshot that was only ever populated by the initial fetch, so it went stale after any points change even when the underlying `freePoints`/`territoryPoints` state was correct.

## Changes
- `apiPointsStore.ts`: `postTerritoryHours` now also applies free points and experience points changes from the response; `postFreePoints`/`postTerritoryPoints`/`postTerritoryHours` now keep the cached `pointsInfo` snapshot in sync.
- `apiWheelStore.ts`: `applyRoll` now also applies territory points, experience points, and territory hours changes from the response, and keeps `pointsInfo` in sync for free/territory points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)