### PR TITLE
Gate app render on system parameters loading with auto-retry

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { RouterView } from 'vue-router'
+import SystemParametersGate from './components/SystemParametersGate.vue'
 import { useShortcuts } from './composables/useShortcuts'
 useShortcuts()
 </script>
 
 <template>
-	<RouterView />
+	<SystemParametersGate>
+		<RouterView />
+	</SystemParametersGate>
 </template>

--- a/src/components/SystemParametersGate.vue
+++ b/src/components/SystemParametersGate.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useFeatureSystemParametersStore } from '../stores/feature/featureSystemParametersStore'
+
+const systemParametersStore = useFeatureSystemParametersStore()
+
+const now = ref(Date.now())
+let interval: ReturnType<typeof setInterval> | null = null
+
+watch(
+	() => systemParametersStore.nextRetryAt,
+	() => {
+		now.value = Date.now()
+	},
+)
+
+onMounted(() => {
+	interval = setInterval(() => {
+		now.value = Date.now()
+	}, 1000)
+})
+
+onUnmounted(() => {
+	if (interval) clearInterval(interval)
+})
+
+const secondsUntilRetry = computed(() => {
+	const nextRetryAt = systemParametersStore.nextRetryAt
+	if (!nextRetryAt) return 0
+
+	return Math.max(0, Math.ceil((nextRetryAt - now.value) / 1000))
+})
+</script>
+
+<template>
+	<slot v-if="systemParametersStore.getAllSystemParametersState.isLoaded" />
+	<div
+		class="system-parameters-error"
+		v-else-if="systemParametersStore.retriesExhausted"
+	>
+		<p class="message">Сервер недоступен</p>
+		<p class="retry-timer">Следующая попытка через {{ secondsUntilRetry }} с</p>
+	</div>
+</template>
+
+<style scoped>
+.system-parameters-error {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	height: 100vh;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	padding: 24px;
+}
+
+.message {
+	font-size: 1.5rem;
+	font-weight: 700;
+	color: #ef4444;
+}
+
+.retry-timer {
+	font-size: 1rem;
+	color: #64748b;
+}
+</style>

--- a/src/stores/feature/featureSystemParametersStore.ts
+++ b/src/stores/feature/featureSystemParametersStore.ts
@@ -1,17 +1,24 @@
 import { defineStore } from 'pinia'
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { StoreName } from '../../enums/storeName'
 import { systemParameterDefs } from '../../constants/systemParameters'
 import type {
 	SystemParameterName,
 	SystemParameterType,
 } from '../../types/systemParameters'
+import { LoadingStatus } from '../../utils/loadingState'
 import { useApiSystemParametersStore } from '../api/apiSystemParametersStore'
+
+const RETRY_DELAYS_MS = [200, 400, 800, 1600]
+const LONG_RETRY_DELAY_MS = 60_000
 
 export const useFeatureSystemParametersStore = defineStore(
 	StoreName.FeatureSystemParameters,
 	() => {
 		const systemParametersStore = useApiSystemParametersStore()
+
+		const retriesExhausted = ref(false)
+		const nextRetryAt = ref<number | null>(null)
 
 		const getByName = <K extends SystemParameterName>(key: K) =>
 			computed(() => {
@@ -55,6 +62,31 @@ export const useFeatureSystemParametersStore = defineStore(
 		const freePointChangeBySandstorm = getByName('freePointChangeBySandstorm')
 
 		const init = () => {
+			let retryAttempt = 0
+
+			watch(
+				() => systemParametersStore.getAllSystemParametersState.status,
+				(status) => {
+					if (status === LoadingStatus.LOADED) {
+						retryAttempt = 0
+						retriesExhausted.value = false
+						nextRetryAt.value = null
+						return
+					}
+
+					if (retryAttempt >= RETRY_DELAYS_MS.length) retriesExhausted.value = true
+
+					const delay =
+						retryAttempt < RETRY_DELAYS_MS.length
+							? RETRY_DELAYS_MS[retryAttempt]
+							: LONG_RETRY_DELAY_MS
+					retryAttempt += 1
+
+					nextRetryAt.value = Date.now() + delay
+					setTimeout(() => systemParametersStore.getAllSystemParameters(), delay)
+				},
+			)
+
 			systemParametersStore.getAllSystemParameters()
 		}
 
@@ -76,6 +108,11 @@ export const useFeatureSystemParametersStore = defineStore(
 			freePointChangeBySandstorm,
 
 			init,
+			getAllSystemParametersState: computed(
+				() => systemParametersStore.getAllSystemParametersState,
+			),
+			retriesExhausted,
+			nextRetryAt,
 		}
 	},
 )


### PR DESCRIPTION
## Summary
- App no longer renders until required system parameters have loaded, instead of rendering with undefined values.
- Failed fetches auto-retry with backoff (200ms, 400ms, 800ms, 5s), then fall back to retrying every minute indefinitely instead of giving up.
- New `SystemParametersGate` component wraps `RouterView` and shows a "server unavailable" message with a live countdown to the next retry once the initial backoff attempts are exhausted, so the user doesn't need to reload the window.