### PR TITLE
Allow editing another player's territory and free points

### DIFF
--- a/src/views/Profile/components/pointsChangeConfigs.ts
+++ b/src/views/Profile/components/pointsChangeConfigs.ts
@@ -1,3 +1,4 @@
+import type { Ref } from 'vue'
 import type { HttpErrorResponse } from '../../../api-facade/http'
 import {
 	ExperienceChangeSource,
@@ -50,10 +51,14 @@ export type PointsChangeConfig = {
 	mapError?: (error: HttpErrorResponse) => string | undefined
 }
 
-export const usePointsChangeConfigs = () => {
+// When set (e.g. on another player's profile page), points are changed for
+// that player instead of the current user, and no "someone else's" picker is shown.
+export const usePointsChangeConfigs = (targetLogin?: Ref<string | undefined>) => {
 	const authStore = useAuthStore()
 	const userStore = useFeatureUserStore()
 	const systemParametersStore = useFeatureSystemParametersStore()
+
+	const resolveLogin = () => targetLogin?.value ?? authStore.login
 
 	const territoryPoints: PointsChangeConfig = {
 		title: 'Изменить очки территорий',
@@ -77,8 +82,9 @@ export const usePointsChangeConfigs = () => {
 		],
 		isLoading: () => userStore.changeTerritoryPointsState.isLoading,
 		submit: ({ reason, desiredChangeValue }) => {
-			if (!authStore.login) return null
-			return userStore.changeTerritoryPoints(authStore.login, {
+			const login = resolveLogin()
+			if (!login) return null
+			return userStore.changeTerritoryPoints(login, {
 				changeSource: reason,
 				desiredChangeValue,
 			})
@@ -110,8 +116,9 @@ export const usePointsChangeConfigs = () => {
 		],
 		isLoading: () => userStore.changeFreePointsState.isLoading,
 		submit: ({ reason, desiredChangeValue }) => {
-			if (!authStore.login) return null
-			return userStore.changeFreePoints(authStore.login, {
+			const login = resolveLogin()
+			if (!login) return null
+			return userStore.changeFreePoints(login, {
 				changeSource: reason,
 				desiredChangeValue,
 			})

--- a/src/views/Users/OtherUserProfileView.vue
+++ b/src/views/Users/OtherUserProfileView.vue
@@ -13,12 +13,15 @@ import {
 import { formatInstant } from '../../utils/temporal'
 import { useFeatureUserStore } from '../../stores/feature/featureUserStore'
 import { RouteName } from '../../router/routeNames'
+import PointsChangeForm from '../Profile/components/PointsChangeForm.vue'
+import { usePointsChangeConfigs } from '../Profile/components/pointsChangeConfigs'
 import PointsHistoryTabs from '../Profile/components/PointsHistoryTabs.vue'
 
 const route = useRoute()
 const userStore = useFeatureUserStore()
 
 const login = computed(() => route.params.login as string)
+const pointsChangeConfigs = usePointsChangeConfigs(login)
 const displayName = computed(() => {
 	const user = userStore.users?.find((u) => u.login === login.value)
 	return user?.displayName ?? login.value
@@ -98,11 +101,17 @@ watch(login, loadAll)
 				"
 			>
 				<div class="metric-card">
-					<span class="metric-label">Очки территорий</span>
+					<div class="metric-card__header">
+						<span class="metric-label">Очки территорий</span>
+						<PointsChangeForm :config="pointsChangeConfigs.territoryPoints" />
+					</div>
 					<div class="metric-value">{{ territoryPoints }}</div>
 				</div>
 				<div class="metric-card">
-					<span class="metric-label">Свободные очки</span>
+					<div class="metric-card__header">
+						<span class="metric-label">Свободные очки</span>
+						<PointsChangeForm :config="pointsChangeConfigs.freePoints" />
+					</div>
 					<div class="metric-value">{{ pointsInfo?.freePoints }}</div>
 				</div>
 			</div>
@@ -292,6 +301,12 @@ watch(login, loadAll)
 	padding: 14px;
 	border: 1px solid #e2e8f0;
 	border-radius: 4px;
+}
+
+.metric-card__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }
 
 .metric-label {


### PR DESCRIPTION
## Summary
- Add edit buttons for "Очки территорий" and "Свободные очки" on another user's profile page, applying the change to that player instead of the current user.
- `usePointsChangeConfigs` now accepts an optional target login ref; when provided, no "someone else's" picker is shown since the target is already the profile being viewed.