### PR TITLE
Redesign players list as one-player-per-row cards

### DIFF
--- a/src/views/Users/OtherUserProfileView.vue
+++ b/src/views/Users/OtherUserProfileView.vue
@@ -85,9 +85,6 @@ watch(login, loadAll)
 					<span class="current-game-label">текущая игра</span>
 					<span class="current-game-value">
 						<span class="current-game-name">{{ currentGame.name }}</span>
-						<span class="game-status-badge">{{
-							gameStateLabel[currentGame.state]
-						}}</span>
 						<span class="item-meta">{{ formatInstant(currentGame.startDate) }}</span>
 					</span>
 				</div>
@@ -278,14 +275,6 @@ watch(login, loadAll)
 
 .current-game-name {
 	font-weight: 500;
-}
-
-.game-status-badge {
-	font-size: 0.75rem;
-	padding: 2px 10px;
-	border: 1px solid #e2e8f0;
-	border-radius: 20px;
-	color: #64748b;
 }
 
 .metrics-row {

--- a/src/views/Users/UsersView.vue
+++ b/src/views/Users/UsersView.vue
@@ -3,10 +3,21 @@ import { onMounted } from 'vue'
 import UiView from '../../components/ui/UiView.vue'
 import { useFeatureUserStore } from '../../stores/feature/featureUserStore'
 import { RouteName } from '../../router/routeNames'
+import UserListItem from './components/UserListItem.vue'
 
 const userStore = useFeatureUserStore()
 
-onMounted(() => userStore.getAllUsers())
+onMounted(async () => {
+	await userStore.getAllUsers()
+
+	for (const user of userStore.otherUsers) {
+		await Promise.all([
+			userStore.getUserCurrentGame(user.login),
+			userStore.getUserPoints(user.login),
+			userStore.getUserTerritoryPoints(user.login),
+		])
+	}
+})
 </script>
 
 <template>
@@ -16,15 +27,14 @@ onMounted(() => userStore.getAllUsers())
 		<p v-if="userStore.getAllNamesState.isLoading">Загрузка...</p>
 		<p v-else-if="userStore.getAllNamesState.isError">Ошибка загрузки</p>
 		<template v-else>
-			<div class="users-grid">
+			<div class="users-list">
 				<RouterLink
 					v-for="user in userStore.otherUsers"
 					:key="user.login"
 					:to="{ name: RouteName.UserDetail, params: { login: user.login } }"
-					class="user-tile"
+					class="user-row"
 				>
-					<span class="user-login">{{ user.login }}</span>
-					<span class="user-meta">{{ user.displayName }}</span>
+					<UserListItem :login="user.login" :display-name="user.displayName" />
 				</RouterLink>
 			</div>
 		</template>
@@ -37,17 +47,16 @@ h1 {
 	align-self: flex-start;
 }
 
-.users-grid {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: 12px;
+.users-list {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 	width: 100%;
 }
 
-.user-tile {
+.user-row {
 	display: flex;
-	flex-direction: column;
-	gap: 2px;
+	align-items: flex-start;
 	padding: 14px;
 	border: 1px solid #e2e8f0;
 	border-radius: 4px;
@@ -55,16 +64,7 @@ h1 {
 	color: inherit;
 }
 
-.user-tile:hover {
+.user-row:hover {
 	background-color: #f8fafc;
-}
-
-.user-login {
-	font-weight: 600;
-}
-
-.user-meta {
-	font-size: 0.8125rem;
-	color: #64748b;
 }
 </style>

--- a/src/views/Users/components/UserListItem.vue
+++ b/src/views/Users/components/UserListItem.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import UiTimestamp from '../../../components/ui/UiTimestamp.vue'
+import { useFeatureUserStore } from '../../../stores/feature/featureUserStore'
+
+type Props = {
+	login: string
+	displayName?: string
+}
+
+const { login, displayName } = defineProps<Props>()
+
+const userStore = useFeatureUserStore()
+
+const currentGame = computed(() => userStore.userCurrentGame[login])
+const territoryPoints = computed(() => userStore.userTerritoryPoints[login])
+const freePoints = computed(() => userStore.userPoints[login]?.freePoints)
+</script>
+
+<template>
+	<div class="avatar"></div>
+
+	<div class="user-card">
+		<div class="user-card__row">
+			<div class="cell cell--name">
+				<span class="user-login">{{ login }}</span>
+				<span class="user-meta">{{ displayName }}</span>
+			</div>
+
+			<div class="cell cell--points">
+				<div class="user-points__item">
+					<svg
+						class="points-icon"
+						viewBox="0 0 16 16"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path
+							d="M2 14V6.5L8 2l6 4.5V14"
+							stroke="currentColor"
+							stroke-width="1.3"
+							stroke-linejoin="round"
+						/>
+						<path d="M2 9.5h12" stroke="currentColor" stroke-width="1.3" />
+					</svg>
+					<span class="metric-value">{{ territoryPoints ?? '…' }}</span>
+				</div>
+				<div class="user-points__item">
+					<svg
+						class="points-icon"
+						viewBox="0 0 16 16"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path
+							d="M8 1.5l1.85 3.9 4.15.6-3 3 .7 4.1L8 11.1 4.3 13.1l.7-4.1-3-3 4.15-.6L8 1.5z"
+							stroke="currentColor"
+							stroke-width="1.1"
+							stroke-linejoin="round"
+						/>
+					</svg>
+					<span class="metric-value">{{ freePoints ?? '…' }}</span>
+				</div>
+			</div>
+		</div>
+
+		<div class="user-card__row" v-if="currentGame">
+			<div class="cell">
+				<span class="current-game-name">{{ currentGame.name }}</span>
+			</div>
+
+			<div class="cell cell--time">
+				<UiTimestamp :time="currentGame.timeSpent" />
+			</div>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.avatar {
+	width: 38px;
+	height: 38px;
+	border-radius: 50%;
+	background-color: #e2e8f0;
+	flex-shrink: 0;
+}
+
+.user-card {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+}
+
+.user-card__row {
+	display: flex;
+	align-items: flex-start;
+}
+
+.cell {
+	flex: 1;
+	display: flex;
+	align-items: flex-start;
+	padding: 8px 14px;
+}
+
+.cell--points {
+	justify-content: flex-end;
+	gap: 16px;
+}
+
+.cell--time {
+	justify-content: flex-end;
+}
+
+.cell--name {
+	flex-direction: column;
+	gap: 2px;
+}
+
+.user-login {
+	font-weight: 600;
+}
+
+.user-meta {
+	font-size: 0.8125rem;
+	color: #64748b;
+}
+
+.user-points__item {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.points-icon {
+	width: 14px;
+	height: 14px;
+	color: #94a3b8;
+	flex-shrink: 0;
+}
+
+.metric-value {
+	font-size: 1rem;
+	font-weight: 600;
+	min-width: 4ch;
+	text-align: left;
+	font-variant-numeric: tabular-nums;
+}
+
+.current-game-name {
+	font-size: 0.8125rem;
+	color: #64748b;
+}
+</style>


### PR DESCRIPTION
## Summary
- Replace the two-column players grid with one row per player, each showing an avatar placeholder, current game (name + elapsed time), territory points, and free points.
- Add `UserListItem.vue` to render a player row as a compact two-line card (name/points on top, current game/time below, hidden entirely when there's no active game).
- Remove the game status badge from the other-user profile's current game card.