### PR TITLE
Fix misleading error messages in points/wheel forms

### DIFF
--- a/src/views/Profile/components/PointsChangeForm.vue
+++ b/src/views/Profile/components/PointsChangeForm.vue
@@ -82,12 +82,14 @@ const onFormSubmit = () => {
 	if (!desiredChangeValue) return
 	if (target.value && applyTarget.value && !targetLogin.value) return
 
-	const request = props.config.submit({
+	const payload = {
 		reason: reason.value,
 		desiredChangeValue,
 		isSomeones: applyTarget.value,
 		targetLogin: targetLogin.value,
-	})
+	}
+
+	const request = props.config.submit(payload)
 
 	if (!request) return
 
@@ -96,7 +98,7 @@ const onFormSubmit = () => {
 			closeModal()
 		})
 		.catch((error: HttpErrorResponse) => {
-			const message = props.config.mapError?.(error)
+			const message = props.config.mapError?.(error, payload)
 			if (message) {
 				errorMessage.value = message
 				return

--- a/src/views/Profile/components/pointsChangeConfigs.ts
+++ b/src/views/Profile/components/pointsChangeConfigs.ts
@@ -48,7 +48,10 @@ export type PointsChangeConfig = {
 	reasons: PointsChangeReasonOption[]
 	isLoading: () => boolean
 	submit: (payload: PointsChangeSubmitPayload) => Promise<unknown> | null
-	mapError?: (error: HttpErrorResponse) => string | undefined
+	mapError?: (
+		error: HttpErrorResponse,
+		payload: PointsChangeSubmitPayload,
+	) => string | undefined
 }
 
 // When set (e.g. on another player's profile page), points are changed for
@@ -180,9 +183,11 @@ export const usePointsChangeConfigs = (targetLogin?: Ref<string | undefined>) =>
 				isSomeones,
 				...(isSomeones && targetLogin ? { login: targetLogin } : {}),
 			}),
-		mapError: (error) =>
+		mapError: (error, payload) =>
 			error.body?.code === 'NOT_ENOUGH_CURRENT_POINTS'
-				? 'У выбранного игрока недостаточно очков территорий. Выберите другого игрока.'
+				? payload.isSomeones
+					? 'У выбранного игрока недостаточно очков территорий.'
+					: 'У вас Недостаточно очков территорий.'
 				: undefined,
 	}
 

--- a/src/views/Wheel/components/WheelEffectApplyForm.vue
+++ b/src/views/Wheel/components/WheelEffectApplyForm.vue
@@ -138,11 +138,11 @@ const submitApply = async () => {
 			emit('close')
 		})
 		.catch((error: HttpErrorResponse) => {
-			if (error.body?.code === 'INCORRECT_CHANGE_SOURCE_VALUE') {
+			if (error.body?.code === 'WRONG_DESIRED_CHANGE_VALUE') {
 				errorMessage.value = 'Значение перекрутов должно быть 0 или больше.'
 				return
 			}
-			throw error
+			errorMessage.value = 'Ошибка'
 		})
 }
 </script>


### PR DESCRIPTION
## Summary
- Wheel roll apply form now matches the correct backend error code (`WRONG_DESIRED_CHANGE_VALUE`) for the roll-value validation message, and shows a generic error instead of silently swallowing unmapped error codes.
- Territory hours change form no longer tells the user to pick another player when the change wasn't targeted at someone else (`isSomeones` is false).