### PR TITLE
Fix timer counting up before counting down

### DIFF
--- a/src/stores/feature/featureTimerStore.ts
+++ b/src/stores/feature/featureTimerStore.ts
@@ -47,7 +47,9 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 
 		const sinceLastAction = Temporal.Now.instant().since(lastActionDate.value)
 
-		const left = durationLeft.value.subtract(sinceLastAction)
+		const left = durationLeft.value.subtract(
+			sinceLastAction.sign < 0 ? ZERO : sinceLastAction,
+		)
 		if (left.sign <= 0) return ZERO
 
 		const floored = left.round({


### PR DESCRIPTION
## Summary
- The timer's `remaining` display briefly counted up before counting down, because a server clock slightly ahead of the client made elapsed time since `lastActionDate` negative, which increased `remaining` above `durationLeft` when subtracted.
- Clamp negative elapsed time to zero in `calcRemaining` so `remaining` never exceeds `durationLeft`.