### PR TITLE
Reduce redundant and misplaced backend API calls

### DIFF
--- a/src/api-facade/api/apiPoints.ts
+++ b/src/api-facade/api/apiPoints.ts
@@ -6,7 +6,6 @@ import type {
 	GetPointsAllInfo,
 	GetPointsInfo,
 	GetTerritoryHours,
-	GetTerritoryPoints,
 	GetTerritoryPointsHistory,
 	PostExperiencePoints,
 	PostFreePoints,
@@ -31,11 +30,6 @@ export const apiPoints = {
 	}: PostTerritoryPoints['request']) =>
 		http
 			.post<PostTerritoryPoints>(`/points/${login}/territory-points`, { body })
-			.then(({ body }) => body),
-
-	getTerritoryPoints: ({ path: { login } }: GetTerritoryPoints['request']) =>
-		http
-			.get<GetTerritoryPoints>(`/points/${login}/territory-points`)
 			.then(({ body }) => body),
 
 	getTerritoryPointsHistory: ({

--- a/src/api-facade/http.ts
+++ b/src/api-facade/http.ts
@@ -39,7 +39,7 @@ const makeRequest = async <T extends object | string = object | string>(
 	const requestTime = Temporal.Now.zonedDateTimeISO()
 	const requestTimestamp = `${requestTime.hour.toString().padStart(2, '0')}:${requestTime.minute.toString().padStart(2, '0')}:${requestTime.second.toString().padStart(2, '0')}.${requestTime.millisecond.toString().padStart(3, '0')}`
 
-	console.log(`[HTTP] ${method} ${fullUrl} | ${requestTimestamp}`, {
+	console.log(`[Request] ${method} ${fullUrl} | ${requestTimestamp}`, {
 		body: opts?.body,
 		headers: {
 			'Content-Type': 'application/json',
@@ -61,7 +61,7 @@ const makeRequest = async <T extends object | string = object | string>(
 		const timestamp = `${time.hour.toString().padStart(2, '0')}:${time.minute.toString().padStart(2, '0')}:${time.second.toString().padStart(2, '0')}.${time.millisecond.toString().padStart(3, '0')}`
 
 		console.log(
-			`[HTTP] ${method} ${fullUrl} - ${response.status} | ${timestamp}`,
+			`[Response] ${method} ${fullUrl} - ${response.status} | ${timestamp}`,
 			{
 				body: responseBody,
 			},
@@ -86,7 +86,6 @@ const makeRequest = async <T extends object | string = object | string>(
 	} catch (error) {
 		await unauthorizedInterceptor(error as HttpErrorResponse)
 
-		console.error(`[HTTP] ${method} ${fullUrl} - ERROR`, error)
 		throw error
 	}
 }

--- a/src/api-facade/requests/points-requests.ts
+++ b/src/api-facade/requests/points-requests.ts
@@ -37,15 +37,6 @@ export type PostTerritoryPoints = {
 	response: TerritoryPointChangeResult
 }
 
-export type GetTerritoryPoints = {
-	request: {
-		path: {
-			login: string
-		}
-	}
-	response: number
-}
-
 export type GetTerritoryPointsHistory = {
 	request: {
 		path: {

--- a/src/stores/api/apiGameStore.ts
+++ b/src/stores/api/apiGameStore.ts
@@ -84,6 +84,27 @@ export const useApiGameStore = defineStore(StoreName.ApiGame, () => {
 		},
 	)
 
+	const [getAllCurrent, getAllCurrentState] = withLoading(async (status) => {
+		if (status.value === LoadingStatus.LOADING) return
+
+		status.value = LoadingStatus.LOADING
+
+		return api.games
+			.getAllCurrent()
+			.then((entries) => {
+				for (const entry of entries) {
+					current.value[entry.login] = entry.currentGame ?? null
+				}
+				status.value = LoadingStatus.LOADED
+
+				return current.value
+			})
+			.catch((e) => {
+				status.value = LoadingStatus.ERROR
+				throw e
+			})
+	})
+
 	const [getHistory, getHistoryState] = withLoading(
 		async (status, login: string) => {
 			if (status.value === LoadingStatus.LOADING) return
@@ -168,6 +189,9 @@ export const useApiGameStore = defineStore(StoreName.ApiGame, () => {
 
 		getCurrent,
 		getCurrentState,
+
+		getAllCurrent,
+		getAllCurrentState,
 
 		getHistory,
 		getHistoryState,

--- a/src/stores/api/apiPointsStore.ts
+++ b/src/stores/api/apiPointsStore.ts
@@ -50,6 +50,29 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 		},
 	)
 
+	const [getAllPointsInfo, getAllPointsInfoState] = withLoading(
+		async (status) => {
+			if (status.value === LoadingStatus.LOADING) return
+
+			status.value = LoadingStatus.LOADING
+
+			return api.points
+				.getPointsAllInfo()
+				.then((entries) => {
+					for (const entry of entries) {
+						pointsInfo.value[entry.login] = entry.pointInfo
+					}
+					status.value = LoadingStatus.LOADED
+
+					return pointsInfo.value
+				})
+				.catch((e) => {
+					status.value = LoadingStatus.ERROR
+					throw e
+				})
+		},
+	)
+
 	const [getFreePointsHistory, getFreePointsHistoryState] = withLoading(
 		async (status, login: string) => {
 			if (status.value === LoadingStatus.LOADING) return
@@ -154,27 +177,6 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 		},
 	)
 
-	const [getTerritoryPoints, getTerritoryPointsState] = withLoading(
-		async (status, login: string) => {
-			if (status.value === LoadingStatus.LOADING) return
-
-			status.value = LoadingStatus.LOADING
-
-			return api.points
-				.getTerritoryPoints({ path: { login } })
-				.then((value) => {
-					territoryPoints.value[login] = value
-					status.value = LoadingStatus.LOADED
-
-					return value
-				})
-				.catch((e) => {
-					status.value = LoadingStatus.ERROR
-					throw e
-				})
-		},
-	)
-
 	const [postExperiencePoints, postExperiencePointsState] = withLoading(
 		async (status, change: PointChange) => {
 			if (status.value === LoadingStatus.LOADING) return
@@ -218,19 +220,32 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 						PointType.TerritoryPoints,
 					)
 					if (territoryPointsResult) {
+						if (authStore.login) {
+							territoryPoints.value[authStore.login] =
+								territoryPointsResult.finalValue
+							if (pointsInfo.value[authStore.login]) {
+								pointsInfo.value[authStore.login].territoryPoints =
+									territoryPointsResult.finalValue
+							}
+						}
+
+						if (
+							change.login &&
+							territoryPoints.value[change.login] !== undefined
+						) {
+							territoryPoints.value[change.login] -=
+								territoryPointsResult.actualChangeValue
+							if (pointsInfo.value[change.login]) {
+								pointsInfo.value[change.login].territoryPoints -=
+									territoryPointsResult.actualChangeValue
+							}
+						}
+
 						const affectedLogins = [authStore.login, change.login].filter(
 							(login): login is string => !!login,
 						)
 
 						for (const affectedLogin of affectedLogins) {
-							api.points
-								.getTerritoryPoints({ path: { login: affectedLogin } })
-								.then((value) => {
-									territoryPoints.value[affectedLogin] = value
-									if (pointsInfo.value[affectedLogin]) {
-										pointsInfo.value[affectedLogin].territoryPoints = value
-									}
-								})
 							api.points
 								.getTerritoryPointsHistory({ path: { login: affectedLogin } })
 								.then((history) => {
@@ -359,6 +374,9 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 		getPointsInfo,
 		getPointsInfoState,
 
+		getAllPointsInfo,
+		getAllPointsInfoState,
+
 		getFreePointsHistory,
 		getFreePointsHistoryState,
 
@@ -373,9 +391,6 @@ export const useApiPointsStore = defineStore(StoreName.ApiPoints, () => {
 
 		getFreePoints,
 		getFreePointsState,
-
-		getTerritoryPoints,
-		getTerritoryPointsState,
 
 		postExperiencePoints,
 		postExperiencePointsState,

--- a/src/stores/feature/featureGameStore.ts
+++ b/src/stores/feature/featureGameStore.ts
@@ -73,15 +73,13 @@ export const useFeatureGameStore = defineStore(StoreName.FeatureGame, () => {
 		return gameStore.finish(login)
 	}
 
-	const init = () => {
-		// get current game on login
+	const watchCurrentGame = () => {
 		watch(
 			() => authStore.login,
 			(login) => login && gameStore.getCurrent(login),
 			{ immediate: true },
 		)
 
-		// refresh game when timer finishes
 		watch(
 			() => timerStore.state,
 			(state) => {
@@ -90,7 +88,6 @@ export const useFeatureGameStore = defineStore(StoreName.FeatureGame, () => {
 				}
 			},
 		)
-
 	}
 
 	return {
@@ -102,7 +99,7 @@ export const useFeatureGameStore = defineStore(StoreName.FeatureGame, () => {
 
 		canRoll,
 
-		init,
+		watchCurrentGame,
 
 		getCurrentState: computed(() => gameStore.getCurrentState),
 

--- a/src/stores/feature/featureTimerStore.ts
+++ b/src/stores/feature/featureTimerStore.ts
@@ -94,14 +94,12 @@ export const useFeatureTimerStore = defineStore(StoreName.FeatureTimer, () => {
 			{ immediate: true },
 		)
 
-		// A new game means a new timer to fetch; finishing/cancelling a
-		// game always leaves no timer, so reset locally without a request
 		watch(
 			() => gameStore.current,
-			(current) => {
-				if (current) {
+			(current, previous) => {
+				if (current && !previous) {
 					timerStore.getCurrent()
-				} else {
+				} else if (!current) {
 					timerStore.reset()
 				}
 			},

--- a/src/stores/feature/featureUserStore.ts
+++ b/src/stores/feature/featureUserStore.ts
@@ -30,14 +30,14 @@ export const useFeatureUserStore = defineStore(StoreName.FeatureUser, () => {
 		() => apiStore.users?.filter((u) => u.login !== authStore.login) ?? [],
 	)
 
-	const init = async () => {
-		await apiStore.getDisplayName()
-	}
+	const getDisplayName = () => apiStore.getDisplayName()
 
 	const getUserCurrentGame = (login: string) => gameStore.getCurrent(login)
+	const getAllUsersCurrentGames = () => gameStore.getAllCurrent()
 	const getUserHistory = (login: string) => gameStore.getHistory(login)
 	const getUserWishlist = (login: string) => gameStore.getWishlist(login)
 	const getUserPoints = (login: string) => pointsStore.getPointsInfo(login)
+	const getAllUsersPoints = () => pointsStore.getAllPointsInfo()
 	const getUserFreePointsHistory = (login: string) =>
 		pointsStore.getFreePointsHistory(login)
 	const getUserTerritoryPointsHistory = (login: string) =>
@@ -46,8 +46,6 @@ export const useFeatureUserStore = defineStore(StoreName.FeatureUser, () => {
 	const getUserExperiencePoints = () => pointsStore.getExperiencePoints()
 	const getUserTerritoryHours = () => pointsStore.getTerritoryHours()
 	const getUserFreePoints = (login: string) => pointsStore.getFreePoints(login)
-	const getUserTerritoryPoints = (login: string) =>
-		pointsStore.getTerritoryPoints(login)
 	const userExperiencePoints = computed(() => pointsStore.experiencePoints)
 	const userTerritoryHours = computed(() => pointsStore.territoryHours)
 	const changeExperiencePoints = (change: PointChange) =>
@@ -71,7 +69,7 @@ export const useFeatureUserStore = defineStore(StoreName.FeatureUser, () => {
 		getAllUsers: apiStore.getAllUsers,
 		setDisplayName: apiStore.setDisplayName,
 
-		init,
+		getDisplayName,
 
 		userCurrentGame: gameStore.current,
 		userHistory: gameStore.history,
@@ -84,10 +82,12 @@ export const useFeatureUserStore = defineStore(StoreName.FeatureUser, () => {
 		userExperiencePoints,
 		userTerritoryHours,
 		userFreePoints: pointsStore.freePoints,
-		userTerritoryPoints: pointsStore.territoryPoints,
 
 		getUserCurrentGame,
 		getUserCurrentGameState: gameStore.getCurrentState,
+
+		getAllUsersCurrentGames,
+		getAllUsersCurrentGamesState: gameStore.getAllCurrentState,
 
 		getUserHistory,
 		getUserHistoryState: gameStore.getHistoryState,
@@ -97,6 +97,9 @@ export const useFeatureUserStore = defineStore(StoreName.FeatureUser, () => {
 
 		getUserPoints,
 		getUserPointsState: pointsStore.getPointsInfoState,
+
+		getAllUsersPoints,
+		getAllUsersPointsState: pointsStore.getAllPointsInfoState,
 
 		getUserFreePointsHistory,
 		getUserFreePointsHistoryState: pointsStore.getFreePointsHistoryState,
@@ -116,9 +119,6 @@ export const useFeatureUserStore = defineStore(StoreName.FeatureUser, () => {
 
 		getUserFreePoints,
 		getUserFreePointsState: pointsStore.getFreePointsState,
-
-		getUserTerritoryPoints,
-		getUserTerritoryPointsState: pointsStore.getTerritoryPointsState,
 
 		changeExperiencePoints,
 		changeExperiencePointsState: pointsStore.postExperiencePointsState,

--- a/src/stores/feature/featureWheelStore.ts
+++ b/src/stores/feature/featureWheelStore.ts
@@ -1,8 +1,6 @@
 import { defineStore } from 'pinia'
-import { computed, watch } from 'vue'
-import { TimerState } from '../../api-facade/models/timers-models'
+import { computed } from 'vue'
 import { StoreName } from '../../enums/storeName'
-import { useApiTimerStore } from '../api/apiTimerStore'
 import { useApiUserStore } from '../api/apiUserStore'
 import { useApiWheelStore } from '../api/apiWheelStore'
 import { useAuthStore } from '../authStore'
@@ -11,7 +9,6 @@ import { useFeatureSystemParametersStore } from './featureSystemParametersStore'
 export const useFeatureWheelStore = defineStore(StoreName.FeatureWheel, () => {
 	const wheelStore = useApiWheelStore()
 	const userStore = useApiUserStore()
-	const timerStore = useApiTimerStore()
 	const authStore = useAuthStore()
 	const systemParametersStore = useFeatureSystemParametersStore()
 
@@ -44,25 +41,7 @@ export const useFeatureWheelStore = defineStore(StoreName.FeatureWheel, () => {
 
 	const clearLastRoll = () => wheelStore.clearLastRoll()
 
-	const init = () => {
-		// Get available roll count on timer end
-		/** @todo maybe always +1 regardless of API response? */
-		watch(
-			() => timerStore.state,
-			(state) => {
-				if (!state || state === TimerState.Finished)
-					wheelStore.getAvailableCount()
-			},
-			{ immediate: true },
-		)
-
-		// Get count on login
-		watch(
-			() => authStore.isLoggedIn,
-			(isLoggedIn) => isLoggedIn && wheelStore.getAvailableCount(),
-			{ immediate: true },
-		)
-	}
+	const getAvailableCount = () => wheelStore.getAvailableCount()
 
 	return {
 		currentEffects,
@@ -71,7 +50,8 @@ export const useFeatureWheelStore = defineStore(StoreName.FeatureWheel, () => {
 		availableRollCount,
 		pendingRoll,
 
-		init,
+		getAvailableCount,
+		getAvailableCountState: wheelStore.getAvailableCountState,
 
 		getHistory,
 		getHistoryState: wheelStore.getHistoryState,

--- a/src/stores/initStores.ts
+++ b/src/stores/initStores.ts
@@ -1,13 +1,7 @@
-import { useFeatureGameStore } from './feature/featureGameStore'
 import { useFeatureSystemParametersStore } from './feature/featureSystemParametersStore'
 import { useFeatureTimerStore } from './feature/featureTimerStore'
-import { useFeatureUserStore } from './feature/featureUserStore'
-import { useFeatureWheelStore } from './feature/featureWheelStore'
 
 export const initStores = () => {
 	useFeatureSystemParametersStore().init()
-	useFeatureWheelStore().init()
-	useFeatureGameStore().init()
 	useFeatureTimerStore().init()
-	useFeatureUserStore().init()
 }

--- a/src/views/Auth/AuthView.vue
+++ b/src/views/Auth/AuthView.vue
@@ -5,13 +5,11 @@ import { type HttpErrorResponse } from '../../api-facade/http'
 import { usePersistentRef } from '../../composables/usePersistentRef'
 import { StoreKey } from '../../services/persistentStorage'
 import { useAuthStore } from '../../stores/authStore'
-import { useFeatureUserStore } from '../../stores/feature/featureUserStore'
 import { RouteName } from '../../router/routeNames'
 import UiButton from '../../components/ui/UiButton.vue'
 
 const router = useRouter()
 const authStore = useAuthStore()
-const userStore = useFeatureUserStore()
 
 const authMode = ref<'login' | 'register'>('login')
 const isRegisterMode = computed(() => authMode.value === 'register')
@@ -133,7 +131,6 @@ const tryLogIn = async () =>
 	authStore
 		.logIn({ login: login.value, password: password.value })
 		.then(() => {
-			userStore.init()
 			router.push({ name: RouteName.Timer })
 		})
 		.catch((e) => {
@@ -177,7 +174,6 @@ const onRegisterSubmit = () => {
 			email: email.value,
 		})
 		.then(() => {
-			userStore.init()
 			router.push({ name: RouteName.Timer })
 		})
 		.catch((e: HttpErrorResponse) => {

--- a/src/views/Games/GamesView.vue
+++ b/src/views/Games/GamesView.vue
@@ -23,6 +23,8 @@ const activeTab = ref<Tab>('current')
 const { current, canRoll, wishlist, enoughGamesInWishlist } = storeToRefs(gameStore)
 const { minimumNumberOfWishlistGames } = storeToRefs(systemParametersStore)
 
+gameStore.watchCurrentGame()
+
 onMounted(() => {
 	if (
 		[LoadingStatus.ERROR, LoadingStatus.INIT].includes(

--- a/src/views/Profile/ProfileView.vue
+++ b/src/views/Profile/ProfileView.vue
@@ -20,6 +20,8 @@ const userStore = useFeatureUserStore()
 const gameStore = useFeatureGameStore()
 const pointsChangeConfigs = usePointsChangeConfigs()
 
+gameStore.watchCurrentGame()
+
 const login = computed(() => authStore.login)
 const displayName = computed(() => userStore.currentUser.displayName)
 
@@ -27,7 +29,7 @@ const pointsInfo = computed(() =>
 	login.value ? (userStore.userPoints[login.value] ?? null) : null,
 )
 const territoryPoints = computed(() =>
-	login.value ? (userStore.userTerritoryPoints[login.value] ?? null) : null,
+	login.value ? (userStore.userPoints[login.value]?.territoryPoints ?? null) : null,
 )
 const experiencePoints = computed(() => userStore.userExperiencePoints)
 const territoryHours = computed(() => userStore.userTerritoryHours)
@@ -42,21 +44,18 @@ const territoryHistory = computed(() =>
 const isLoading = computed(
 	() =>
 		userStore.getUserPointsState.isLoading ||
-		userStore.getUserTerritoryPointsState.isLoading ||
 		userStore.getUserExperiencePointsState.isLoading ||
 		userStore.getUserTerritoryHoursState.isLoading,
 )
 const isError = computed(
 	() =>
 		userStore.getUserPointsState.isError ||
-		userStore.getUserTerritoryPointsState.isError ||
 		userStore.getUserExperiencePointsState.isError ||
 		userStore.getUserTerritoryHoursState.isError,
 )
 const isLoaded = computed(
 	() =>
 		userStore.getUserPointsState.isLoaded &&
-		userStore.getUserTerritoryPointsState.isLoaded &&
 		userStore.getUserExperiencePointsState.isLoaded &&
 		userStore.getUserTerritoryHoursState.isLoaded,
 )
@@ -69,8 +68,8 @@ const freeLabelFor = (source: string) =>
 const loadAll = () => {
 	if (!login.value) return
 
+	userStore.getDisplayName()
 	userStore.getUserPoints(login.value)
-	userStore.getUserTerritoryPoints(login.value)
 	userStore.getUserExperiencePoints()
 	userStore.getUserTerritoryHours()
 	userStore.getUserFreePointsHistory(login.value)

--- a/src/views/Timer/TimerView.vue
+++ b/src/views/Timer/TimerView.vue
@@ -1,17 +1,23 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import { computed } from 'vue'
+import { computed, onMounted, watch } from 'vue'
 import { RouterLink } from 'vue-router'
 import { TimerState } from '../../api-facade/models/timers-models.ts'
 import UiTimestamp from '../../components/ui/UiTimestamp.vue'
 import { RouteName } from '../../router/routeNames'
+import { useAuthStore } from '../../stores/authStore'
 import { useFeatureGameStore } from '../../stores/feature/featureGameStore'
 import { useFeatureTimerStore } from '../../stores/feature/featureTimerStore'
+import { useFeatureWheelStore } from '../../stores/feature/featureWheelStore'
 import UiView from '../../components/ui/UiView.vue'
 import { timerStateLabel } from './constants/timerStateLabel'
 
+const authStore = useAuthStore()
 const timerStore = useFeatureTimerStore()
 const gameStore = useFeatureGameStore()
+const wheelStore = useFeatureWheelStore()
+
+gameStore.watchCurrentGame()
 
 const {
 	durationTotal,
@@ -42,6 +48,16 @@ const timerButtonLabel = computed(() =>
 const onStartButtonClick = () => {
 	timerStore.toggle()
 }
+
+onMounted(() => {
+	if (authStore.isLoggedIn) wheelStore.getAvailableCount()
+})
+
+watch(state, (newState) => {
+	if (newState === TimerState.Finished && authStore.isLoggedIn) {
+		wheelStore.getAvailableCount()
+	}
+})
 </script>
 
 <template>

--- a/src/views/Users/OtherUserProfileView.vue
+++ b/src/views/Users/OtherUserProfileView.vue
@@ -28,7 +28,7 @@ const displayName = computed(() => {
 })
 
 type Tab = 'effects' | 'games' | 'points'
-const activeTab = ref<Tab>('effects')
+const activeTab = ref<Tab | null>(null)
 
 const comingSoonTabs = ['перки', 'характеристики', 'предметы', 'квесты']
 
@@ -37,7 +37,7 @@ const currentGame = computed(
 )
 const pointsInfo = computed(() => userStore.userPoints[login.value] ?? null)
 const territoryPoints = computed(
-	() => userStore.userTerritoryPoints[login.value] ?? null,
+	() => userStore.userPoints[login.value]?.territoryPoints ?? null,
 )
 const gamesHistory = computed(() => userStore.userHistory[login.value] ?? [])
 const effectsHistory = computed(() => userStore.userEffects[login.value] ?? [])
@@ -53,18 +53,30 @@ const territoryLabelFor = (source: string) =>
 const freeLabelFor = (source: string) =>
 	freePointChangeSourceLabel[source as FreePointChangeSource]
 
-const loadAll = () => {
+const loadEager = () => {
 	userStore.getUserCurrentGame(login.value)
 	userStore.getUserPoints(login.value)
-	userStore.getUserTerritoryPoints(login.value)
-	userStore.getUserHistory(login.value)
-	userStore.getUserEffects(login.value)
-	userStore.getUserFreePointsHistory(login.value)
-	userStore.getUserTerritoryPointsHistory(login.value)
 }
 
-onMounted(loadAll)
-watch(login, loadAll)
+const loadForTab = (tab: Tab) => {
+	if (tab === 'effects') userStore.getUserEffects(login.value)
+	else if (tab === 'games') userStore.getUserHistory(login.value)
+	else if (tab === 'points') {
+		userStore.getUserFreePointsHistory(login.value)
+		userStore.getUserTerritoryPointsHistory(login.value)
+	}
+}
+
+onMounted(loadEager)
+
+watch(login, () => {
+	activeTab.value = null
+	loadEager()
+})
+
+watch(activeTab, (tab) => {
+	if (tab) loadForTab(tab)
+})
 </script>
 
 <template>
@@ -90,13 +102,7 @@ watch(login, loadAll)
 				</div>
 			</div>
 
-			<div
-				class="metrics-row"
-				v-if="
-					userStore.getUserPointsState.isLoaded &&
-					userStore.getUserTerritoryPointsState.isLoaded
-				"
-			>
+			<div class="metrics-row" v-if="userStore.getUserPointsState.isLoaded">
 				<div class="metric-card">
 					<div class="metric-card__header">
 						<span class="metric-label">Очки территорий</span>

--- a/src/views/Users/UsersView.vue
+++ b/src/views/Users/UsersView.vue
@@ -10,13 +10,10 @@ const userStore = useFeatureUserStore()
 onMounted(async () => {
 	await userStore.getAllUsers()
 
-	for (const user of userStore.otherUsers) {
-		await Promise.all([
-			userStore.getUserCurrentGame(user.login),
-			userStore.getUserPoints(user.login),
-			userStore.getUserTerritoryPoints(user.login),
-		])
-	}
+	await Promise.all([
+		userStore.getAllUsersCurrentGames(),
+		userStore.getAllUsersPoints(),
+	])
 })
 </script>
 

--- a/src/views/Users/components/UserListItem.vue
+++ b/src/views/Users/components/UserListItem.vue
@@ -13,7 +13,7 @@ const { login, displayName } = defineProps<Props>()
 const userStore = useFeatureUserStore()
 
 const currentGame = computed(() => userStore.userCurrentGame[login])
-const territoryPoints = computed(() => userStore.userTerritoryPoints[login])
+const territoryPoints = computed(() => userStore.userPoints[login]?.territoryPoints)
 const freePoints = computed(() => userStore.userPoints[login]?.freePoints)
 </script>
 

--- a/src/views/Wheel/WheelView.vue
+++ b/src/views/Wheel/WheelView.vue
@@ -2,18 +2,21 @@
 import UiButton from '../../components/ui/UiButton.vue'
 import trashIcon from '../../assets/icons/trash.svg'
 import { useFeatureWheelStore } from '../../stores/feature/featureWheelStore'
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import UiView from '../../components/ui/UiView.vue'
 import WheelEffectApplyForm from './components/WheelEffectApplyForm.vue'
 import WheelEffectCard from './components/WheelEffectCard.vue'
+import { TimerState } from '../../api-facade/models/timers-models'
 import type { RolledWheelEffectDto } from '../../api-facade/models/wheel-effects-models'
 import { formatInstant } from '../../utils/temporal'
 import { useAuthStore } from '../../stores/authStore'
+import { useFeatureTimerStore } from '../../stores/feature/featureTimerStore'
 import { useFeatureUserStore } from '../../stores/feature/featureUserStore'
 
 const wheelStore = useFeatureWheelStore()
 const authStore = useAuthStore()
 const userStore = useFeatureUserStore()
+const timerStore = useFeatureTimerStore()
 
 const effectsHistory = computed(() =>
 	authStore.login ? (userStore.userEffects[authStore.login] ?? []) : [],
@@ -43,6 +46,7 @@ const centerIndex = computed(() =>
 const isReroll = ref(false)
 
 const onRollButtonClick = () => {
+	wheelStore.getAvailableEffects()
 	wheelStore.roll(isReroll.value)
 }
 
@@ -64,11 +68,19 @@ const closeModal = () => {
 
 onMounted(() => {
 	wheelStore.getLastRoll()
-	wheelStore.getAvailableEffects()
-	wheelStore.getAllUsers()
 
 	if (authStore.login) userStore.getUserEffects(authStore.login)
+	if (authStore.isLoggedIn) wheelStore.getAvailableCount()
 })
+
+watch(
+	() => timerStore.state,
+	(state) => {
+		if (state === TimerState.Finished && authStore.isLoggedIn) {
+			wheelStore.getAvailableCount()
+		}
+	},
+)
 </script>
 
 <template>

--- a/src/views/Wheel/components/WheelEffectApplyForm.vue
+++ b/src/views/Wheel/components/WheelEffectApplyForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import type { HttpErrorResponse } from '../../../api-facade/http'
 import { FreePointChangeSource } from '../../../api-facade/models/points-models'
 import type {
@@ -7,7 +7,6 @@ import type {
 	WheelEffectPointChange,
 } from '../../../api-facade/models/wheel-effects-models'
 import { useAuthStore } from '../../../stores/authStore'
-import { useFeatureUserStore } from '../../../stores/feature/featureUserStore'
 import { useFeatureWheelStore } from '../../../stores/feature/featureWheelStore'
 
 const props = defineProps<{
@@ -20,7 +19,6 @@ const emit = defineEmits<{
 
 const wheelStore = useFeatureWheelStore()
 const authStore = useAuthStore()
-const userStore = useFeatureUserStore()
 
 type OtherPlayerRow = {
 	id: number
@@ -39,6 +37,16 @@ let nextRowId = 0
 const otherUsers = computed(() =>
 	(wheelStore.users ?? []).filter((user) => user.login !== authStore.login),
 )
+
+const currentUserDisplayName = computed(
+	() =>
+		(wheelStore.users ?? []).find((user) => user.login === authStore.login)
+			?.displayName ?? authStore.login,
+)
+
+onMounted(() => {
+	wheelStore.getAllUsers()
+})
 
 const availableLoginsForRow = (row: OtherPlayerRow) =>
 	otherUsers.value.filter(
@@ -133,8 +141,7 @@ const submitApply = async () => {
 
 	await wheelStore
 		.applyRoll(props.effect.name, changes)
-		.then(async () => {
-			if (authStore.login) await userStore.getUserEffects(authStore.login)
+		.then(() => {
 			emit('close')
 		})
 		.catch((error: HttpErrorResponse) => {
@@ -158,9 +165,7 @@ const submitApply = async () => {
 		</div>
 
 		<div class="user-row">
-			<span class="user-name">{{
-				userStore.currentUser.displayName ?? userStore.currentUser.login
-			}}</span>
+			<span class="user-name">{{ currentUserDisplayName }}</span>
 			<input
 				class="point-input"
 				type="number"


### PR DESCRIPTION
## Summary
- Replace UsersView's `1+3N` per-user fetch loop with the existing bulk endpoints (`games/all/current`, `points/all/info`)
- Drop the separate territory-points endpoint wherever `pointsInfo` already carries the value, and apply `postTerritoryHours`' territory points delta directly/optimistically instead of blind refetches for both affected users
- Make `OtherUserProfileView` load tab data lazily, with no tab active by default
- Remove a dead history refetch fired after applying a wheel effect
- Fix a duplicate `GET /timers/current` firing on every timer finish
- Scope wheel roll-count, available-effects, current-game and display-name fetches to the views that actually need them (Wheel, Timer, Games, Profile) instead of firing app-wide on every page
- Guard the roll-count fetch against firing right after logout, and fix a mount-time race where it could silently skip fetching depending on timer state
- Source the current user's display name from the already-loaded users list in the wheel effect apply form instead of a separate endpoint

## Backend follow-ups (not part of this PR)
A few remaining redundant calls need a backend contract change (making `postTerritoryHours` return per-login results like `applyRoll` already does, and including history entries in point-change POST responses) to be fully removed. Documented separately for the `fgg-server` repo.